### PR TITLE
Bugfix - Send EventCategory of product impression

### DIFF
--- a/GoogleAnalyticsEventForwarder.js
+++ b/GoogleAnalyticsEventForwarder.js
@@ -210,7 +210,7 @@
                     });
                 });
 
-                sendEcommerceEvent(data.EventDataType, outputDimensionsAndMetrics);
+                sendEcommerceEvent(data.EventCategory, outputDimensionsAndMetrics);
             }
             else if (data.PromotionAction) {
                 // Promotion event


### PR DESCRIPTION
Resolves desk ticket - https://mparticle.desk.com/web/agent/case/5748

Looks like we were sending the eventDataType of 16 over, which translated into commerce type of product purchase.