### PR TITLE
Bugfix - Respect custom dimensions/metrics in logPageView

### DIFF
--- a/GoogleAnalyticsEventForwarder.js
+++ b/GoogleAnalyticsEventForwarder.js
@@ -107,7 +107,7 @@
 
                 try {
                     if (event.EventDataType == MessageType.PageView) {
-                        logPageView(event);
+                        logPageView(outputDimensionsAndMetrics);
                         reportEvent = true;
                     }
                     else if (event.EventDataType == MessageType.Commerce) {


### PR DESCRIPTION
Has been an ongoing bug. The event doesn't need to be passed to logPageView, the outputDimensionsAndMetrics do. Tested on GA UI and works now. Resolves https://mparticle.desk.com/web/agent/case/5747