### PR TITLE
Bugfix duplicate dimension mappings

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -2,46 +2,13 @@
     "env": {
         "browser": true
     },
-    "extends": "eslint:recommended",
+    "extends": ["plugin:prettier/recommended", "eslint:recommended"],
+    "plugins": ["prettier"],
     "rules": {
-        "indent": [
-            "error",
-            4,
-            { "SwitchCase": 1}
-        ],
-        "linebreak-style": [
-            "error",
-            "unix"
-        ],
-        "quotes": [
-            "error",
-            "single"
-        ],
-        "semi": [
-            "error",
-            "always"
-        ],
-        "no-unneeded-ternary": [
-            "error",
-            { "defaultAssignment": false }
-        ],
-        "comma-dangle": [
-            "error",
-            "never"
-        ],
-        "curly": [
-            "error",
-            "multi-line"
-        ],
-        "comma-spacing": [
-            "error",
-            { before: false, after: true }
-        ],
-        "quote-props": [
-            "error",
-            "as-needed",
-            { keywords: false, unnecessary: true, numbers: false }
-        ],
-        "no-multi-spaces": "error",
+        "prettier/prettier": "error",
+        "no-prototype-builtins": "off",
+        "no-empty": "off",
+        "no-useless-escape": "off",
+        "no-unexpected-multiline": "off"
     }
 }

--- a/.prettierignore
+++ b/.prettierignore
@@ -1,0 +1,1 @@
+GoogleAnalyticsEventForwarder.js

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,9 @@
+## Releases
+
+--
+
+#### 2.0.1 - 2019-10-23
+
+-   Bugfix - Enable duplicate mappings
+-   Add version number
+-   Cleanup - Implement Prettier, update eslint file, remove isObject dependency

--- a/GoogleAnalyticsEventForwarder.js
+++ b/GoogleAnalyticsEventForwarder.js
@@ -17,6 +17,7 @@ var mpGoogleAnalyticsKit = (function (exports) {
 
         var name = 'GoogleAnalyticsEventForwarder',
             moduleId = 6,
+            version = '2.0.1',
             MessageType = {
                 SessionStart: 1,
                 SessionEnd: 2,
@@ -545,11 +546,16 @@ var mpGoogleAnalyticsKit = (function (exports) {
         }
 
         var GoogleAnalyticsEventForwarder = {
-            register: register
+            register: register,
+            getVersion: function() {
+                return version;
+            }
         };
     var GoogleAnalyticsEventForwarder_1 = GoogleAnalyticsEventForwarder.register;
+    var GoogleAnalyticsEventForwarder_2 = GoogleAnalyticsEventForwarder.getVersion;
 
     exports.default = GoogleAnalyticsEventForwarder;
+    exports.getVersion = GoogleAnalyticsEventForwarder_2;
     exports.register = GoogleAnalyticsEventForwarder_1;
 
     return exports;

--- a/GoogleAnalyticsEventForwarder.js
+++ b/GoogleAnalyticsEventForwarder.js
@@ -1,579 +1,557 @@
 var mpGoogleAnalyticsKit = (function (exports) {
-  /*!
-   * isobject <https://github.com/jonschlinkert/isobject>
-   *
-   * Copyright (c) 2014-2017, Jon Schlinkert.
-   * Released under the MIT License.
-   */
-
-  function isObject(val) {
-    return val != null && typeof val === 'object' && Array.isArray(val) === false;
-  }
-
-  /* eslint-disable no-undef*/
-  //
-  //  Copyright 2019 mParticle, Inc.
-  //
-  //  Licensed under the Apache License, Version 2.0 (the "License");
-  //  you may not use this file except in compliance with the License.
-  //  You may obtain a copy of the License at
-  //
-  //      http://www.apache.org/licenses/LICENSE-2.0
-  //
-  //  Unless required by applicable law or agreed to in writing, software
-  //  distributed under the License is distributed on an "AS IS" BASIS,
-  //  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-  //  See the License for the specific language governing permissions and
-  //  limitations under the License.
-
-      
-
-      var name = 'GoogleAnalyticsEventForwarder',
-          moduleId = 6,
-          MessageType = {
-              SessionStart: 1,
-              SessionEnd: 2,
-              PageView: 3,
-              PageEvent: 4,
-              CrashReport: 5,
-              OptOut: 6,
-              Commerce: 16
-          },
-          trackerCount = 1,
-          NON_INTERACTION_FLAG = 'Google.NonInteraction',
-          CATEGORY = 'Google.Category',
-          LABEL = 'Google.Label',
-          PAGE = 'Google.Page',
-          VALUE = 'Google.Value',
-          HITTYPE = 'Google.HitType';
-
-      var constructor = function() {
-          var self = this,
-              isInitialized = false,
-              isEnhancedEcommerceLoaded = false,
-              forwarderSettings,
-              reportingService,
-              trackerId = null,
-              eventLevelMap = {
-                  customDimensions: {},
-                  customMetrics: {}
-              },
-              userLevelMap = {
-                  customDimensions: {},
-                  customMetrics: {}
-              },
-              productLevelMap = {
-                  customDimensions: {},
-                  customMetrics: {}
-              };
-
-          self.name = name;
-
-          function createTrackerId() {
-              return 'mpgaTracker' + trackerCount++;
-          }
-
-          function createCmd(cmd) {
-              // Prepends the specified command with the tracker id
-              return trackerId + '.' + cmd;
-          }
-
-          function getEventTypeName(eventType) {
-              return mParticle.EventType.getName(eventType);
-          }
-
-          function formatDimensionOrMetric(attr) {
-              return attr.replace(/ /g, '').toLowerCase();
-          }
-
-          function applyCustomDimensionsAndMetrics(event, outputDimensionsAndMetrics) {
-              // apply custom dimensions and metrics to each event, product, or user if respective attributes exist
-              if (event.EventAttributes && Object.keys(event.EventAttributes).length) {
-                  applyCustomDimensionsMetricsForSourceAttributes(event.EventAttributes, outputDimensionsAndMetrics, eventLevelMap);
-              }
-
-              if (event.UserAttributes && Object.keys(event.UserAttributes).length) {
-                  applyCustomDimensionsMetricsForSourceAttributes(event.UserAttributes, outputDimensionsAndMetrics, userLevelMap);
-              }
-          }
-
-          function applyCustomDimensionsMetricsForSourceAttributes(attributes, targetDimensionsAndMetrics, mapLevel) {
-              for (var cdKey in mapLevel.customDimensions) {
-                  for (attrName in attributes) {
-                      if (mapLevel.customDimensions[cdKey] === attrName) {
-                          targetDimensionsAndMetrics[cdKey] = attributes[attrName];
-                      }
-                  }
-              }
-
-              for (var cmKey in mapLevel.customMetrics) {
-                  for (attrName in attributes) {
-                      if (mapLevel.customMetrics[cmKey] === attrName) {
-                          targetDimensionsAndMetrics[cmKey] = attributes[attrName];
-                      }
-                  }
-              }
-          }
-
-          function applyCustomFlags(flags, outputDimensionsAndMetrics) {
-              if (flags.hasOwnProperty(NON_INTERACTION_FLAG)) {
-                  outputDimensionsAndMetrics['nonInteraction'] = flags[NON_INTERACTION_FLAG];
-              }
-          }
-
-          function processEvent(event) {
-              var outputDimensionsAndMetrics = {};
-              var reportEvent = false;
-
-              if (isInitialized) {
-                  event.ExpandedEventCount = 0;
-
-                  applyCustomDimensionsAndMetrics(event, outputDimensionsAndMetrics);
-
-                  if (event.CustomFlags && Object.keys(event.CustomFlags).length) {
-                      applyCustomFlags(event.CustomFlags, outputDimensionsAndMetrics);
-                  }
-
-                  try {
-                      if (event.EventDataType == MessageType.PageView) {
-                          logPageView(event, outputDimensionsAndMetrics, event.CustomFlags);
-                          reportEvent = true;
-                      }
-                      else if (event.EventDataType == MessageType.Commerce) {
-                          logCommerce(event, outputDimensionsAndMetrics, event.CustomFlags);
-                          reportEvent = true;
-                      }
-                      else if (event.EventDataType == MessageType.PageEvent) {
-                          reportEvent = true;
-
-                          logEvent(event, outputDimensionsAndMetrics, event.CustomFlags);
-                      }
-
-                      if (reportEvent && reportingService) {
-                          reportingService(self, event);
-                      }
-
-                      return 'Successfully sent to ' + name;
-                  }
-                  catch (e) {
-                      return 'Failed to send to: ' + name + ' ' + e;
-                  }
-              }
-
-              return 'Can\'t send to forwarder ' + name + ', not initialized';
-          }
-
-          function setUserIdentity(id, type) {
-              if (isInitialized) {
-                  if (forwarderSettings.useCustomerId == 'True' && type == window.mParticle.IdentityType.CustomerId) {
-                      if (forwarderSettings.classicMode == 'True') ;
-                      else {
-                          ga(createCmd('set'), 'userId', window.mParticle.generateHash(id));
-                      }
-                  }
-              }
-              else {
-                  return 'Can\'t call setUserIdentity on forwarder ' + name + ', not initialized';
-              }
-          }
-
-          function addEcommerceProduct(product, updatedProductDimentionAndMetrics) {
-              var productAttrs = {
-                  id: product.Sku,
-                  name: product.Name,
-                  category: product.Category,
-                  brand: product.Brand,
-                  variant: product.Variant,
-                  price: product.Price,
-                  coupon: product.CouponCode,
-                  quantity: product.Quantity
-              };
-
-              for (var attr in updatedProductDimentionAndMetrics) {
-                  if (updatedProductDimentionAndMetrics.hasOwnProperty(attr)) {
-                      productAttrs[attr] = updatedProductDimentionAndMetrics[attr];
-                  }
-              }
-
-              ga(createCmd('ec:addProduct'), productAttrs);
-          }
-
-          function addEcommerceProductImpression(product) {
-              ga(createCmd('ec:addImpression'), {
-                  id: product.Sku,
-                  name: product.Name,
-                  type: 'view',
-                  category: product.Category,
-                  brand: product.Brand,
-                  variant: product.Variant
-              });
-          }
-
-          function sendEcommerceEvent(type, outputDimensionsAndMetrics, customFlags) {
-              ga(createCmd('send'), customFlags && customFlags[HITTYPE] ? customFlags[HITTYPE] : 'event', 'eCommerce', getEventTypeName(type), outputDimensionsAndMetrics);
-          }
-
-          function logCommerce(data, outputDimensionsAndMetrics, customFlags) {
-              if (!isEnhancedEcommerceLoaded) {
-                  ga(createCmd('require'), 'ec');
-                  isEnhancedEcommerceLoaded = true;
-              }
-
-              if (data.CurrencyCode) {
-                  // Set currency code if present
-                  ga(createCmd('set'), '&cu', data.CurrencyCode);
-              }
-
-              if (data.ProductImpressions) {
-                  // Impression event
-                  data.ProductImpressions.forEach(function(impression) {
-                      impression.ProductList.forEach(function(product) {
-                          addEcommerceProductImpression(product);
-                      });
-                  });
-
-                  sendEcommerceEvent(data.EventCategory, outputDimensionsAndMetrics, customFlags);
-              }
-              else if (data.PromotionAction) {
-                  // Promotion event
-                  data.PromotionAction.PromotionList.forEach(function(promotion) {
-                      ga(createCmd('ec:addPromo'), {
-                          id: promotion.Id,
-                          name: promotion.Name,
-                          creative: promotion.Creative,
-                          position: promotion.Position
-                      });
-                  });
-
-                  if (data.PromotionAction.PromotionActionType == mParticle.PromotionType.PromotionClick) {
-                      ga(createCmd('ec:setAction'), 'promo_click');
-                  }
-
-                  sendEcommerceEvent(data.EventDataType, outputDimensionsAndMetrics, customFlags);
-              }
-              else if (data.ProductAction) {
-                  if (data.ProductAction.ProductActionType == mParticle.ProductActionType.Purchase) {
-                      data.ProductAction.ProductList.forEach(function(product) {
-                          var updatedProductDimentionAndMetrics = {};
-                          applyCustomDimensionsMetricsForSourceAttributes(product.Attributes, updatedProductDimentionAndMetrics, productLevelMap);
-                          addEcommerceProduct(product, updatedProductDimentionAndMetrics);
-                      });
-
-                      ga(createCmd('ec:setAction'), 'purchase', {
-                          id: data.ProductAction.TransactionId,
-                          affiliation: data.ProductAction.Affiliation,
-                          revenue: data.ProductAction.TotalAmount,
-                          tax: data.ProductAction.TaxAmount,
-                          shipping: data.ProductAction.ShippingAmount,
-                          coupon: data.ProductAction.CouponCode
-                      });
-
-                      sendEcommerceEvent(data.EventDataType, outputDimensionsAndMetrics, customFlags);
-                  }
-                  else if (data.ProductAction.ProductActionType == mParticle.ProductActionType.Refund) {
-                      if (data.ProductAction.ProductList.length) {
-                          data.ProductAction.ProductList.forEach(function(product) {
-                              var productAttrs = {
-                                  id: product.Sku,
-                                  quantity: product.Quantity
-                              };
-                              applyCustomDimensionsMetricsForSourceAttributes(product.Attributes, productAttrs, productLevelMap);
-                              ga(createCmd('ec:addProduct'), productAttrs);
-                          });
-                      }
-
-                      ga(createCmd('ec:setAction'), 'refund', {
-                          id: data.ProductAction.TransactionId
-                      });
-
-                      sendEcommerceEvent(data.EventDataType, outputDimensionsAndMetrics, customFlags);
-                  }
-                  else if (data.ProductAction.ProductActionType == mParticle.ProductActionType.AddToCart ||
-                      data.ProductAction.ProductActionType == mParticle.ProductActionType.RemoveFromCart) {
-                      var updatedProductDimentionAndMetrics = {};
-                      data.ProductAction.ProductList.forEach(function(product) {
-                          applyCustomDimensionsMetricsForSourceAttributes(product.Attributes, updatedProductDimentionAndMetrics, productLevelMap);
-                          addEcommerceProduct(product, updatedProductDimentionAndMetrics);
-                      });
-
-                      ga(createCmd('ec:setAction'),
-                          data.ProductAction.ProductActionType == mParticle.ProductActionType.AddToCart ? 'add' : 'remove');
-
-                      sendEcommerceEvent(data.EventDataType, outputDimensionsAndMetrics, customFlags);
-                  }
-                  else if (data.ProductAction.ProductActionType == mParticle.ProductActionType.Checkout) {
-                      data.ProductAction.ProductList.forEach(function(product) {
-                          var updatedProductDimentionAndMetrics = {};
-                          applyCustomDimensionsMetricsForSourceAttributes(product.Attributes, updatedProductDimentionAndMetrics, productLevelMap);
-                          addEcommerceProduct(product, updatedProductDimentionAndMetrics);
-                      });
-
-                      ga(createCmd('ec:setAction'), 'checkout', {
-                          step: data.ProductAction.CheckoutStep,
-                          option: data.ProductAction.CheckoutOptions
-                      });
-
-                      sendEcommerceEvent(data.EventDataType, outputDimensionsAndMetrics, customFlags);
-                  }
-                  else if (data.ProductAction.ProductActionType == mParticle.ProductActionType.Click) {
-                      data.ProductAction.ProductList.forEach(function(product) {
-                          var updatedProductDimentionAndMetrics = {};
-                          applyCustomDimensionsMetricsForSourceAttributes(product.Attributes, updatedProductDimentionAndMetrics, productLevelMap);
-                          addEcommerceProduct(product, updatedProductDimentionAndMetrics);
-                      });
-
-                      ga(createCmd('ec:setAction'), 'click');
-                      sendEcommerceEvent(data.EventDataType, outputDimensionsAndMetrics, customFlags);
-                  }
-                  else if (data.ProductAction.ProductActionType == mParticle.ProductActionType.ViewDetail) {
-                      data.ProductAction.ProductList.forEach(function(product) {
-                          var updatedProductDimentionAndMetrics = {};
-                          applyCustomDimensionsMetricsForSourceAttributes(product.Attributes, updatedProductDimentionAndMetrics, productLevelMap);
-                          addEcommerceProduct(product );
-                      });
-
-                      ga(createCmd('ec:setAction'), 'detail');
-                      ga(createCmd('send'), customFlags && customFlags[HITTYPE] ? customFlags[HITTYPE] : 'event', 'eCommerce', getEventTypeName(data.EventCategory), outputDimensionsAndMetrics);
-                  }
-              }
-          }
-
-          function logPageView(event, outputDimensionsAndMetrics, customFlags) {
-              if (forwarderSettings.classicMode == 'True') {
-                  _gaq.push(['_trackPageview']);
-              }
-              else {
-                  if (event.CustomFlags && event.CustomFlags[PAGE]) {
-                      ga(createCmd('set'), 'page', event.CustomFlags[PAGE]);
-                  }
-                  ga(createCmd('send'), customFlags && customFlags[HITTYPE] ? customFlags[HITTYPE] : 'pageview', outputDimensionsAndMetrics);
-              }
-          }
-
-          function logEvent(data, outputDimensionsAndMetrics, customFlags) {
-              var label = '',
-                  category = getEventTypeName(data.EventCategory),
-                  value;
-
-              if (data.EventAttributes) {
-                  if (data.EventAttributes.label) {
-                      label = data.EventAttributes.label;
-                  }
-
-                  if (data.EventAttributes.value) {
-                      value = parseInt(data.EventAttributes.value, 10);
-
-                      // Test for NaN
-                      if (value != value) {
-                          value = null;
-                      }
-                  }
-
-                  if (data.EventAttributes.category) {
-                      category = data.EventAttributes.category;
-                  }
-              }
-
-              if(data.CustomFlags) {
-                  var googleCategory = data.CustomFlags[CATEGORY],
-                      googleLabel = data.CustomFlags[LABEL],
-                      googleValue = parseInt(data.CustomFlags[VALUE], 10);
-
-                  if (googleCategory) {
-                      category = googleCategory;
-                  }
-
-                  if (googleLabel) {
-                      label = googleLabel;
-                  }
-
-                  // Ensure not NaN
-                  if (googleValue == googleValue) {
-                      value = googleValue;
-                  }
-              }
-
-              if (forwarderSettings.classicMode == 'True') {
-                  _gaq.push(['_trackEvent',
-                      category,
-                      data.EventName,
-                      label,
-                      value]);
-              }
-              else {
-                  ga(createCmd('send'),
-                      customFlags && customFlags[HITTYPE] ? customFlags[HITTYPE] : 'event',
-                      category,
-                      data.EventName,
-                      label,
-                      value,
-                      outputDimensionsAndMetrics);
-              }
-          }
-
-          function checkForDuplicateMapping(dimensionOrMetric, eventLevelMap) {
-              var existingMapper = eventLevelMap['customDimensions'][formatDimensionOrMetric(dimensionOrMetric.value)];
-              if (existingMapper) {
-                  console.log('Warning: both ' + existingMapper + ' & ' + dimensionOrMetric.map + ' are mapped to ' + dimensionOrMetric.value + '. ' + dimensionOrMetric.map + ' is replacing ' + existingMapper + '. If this is a mistake, please revisit the Google Analytics settings at app.mparticle.com. Otherwise, please ignore this warning.');
-              }
-          }
-
-          function initForwarder(settings, service, testMode, tid) {
-              try {
-                  forwarderSettings = settings;
-                  reportingService = service;
-                  isTesting = testMode;
-
-                  if (!tid) {
-                      trackerId = createTrackerId();
-                  }
-                  else {
-                      trackerId = tid;
-                  }
-
-                  if (forwarderSettings.classicMode == 'True') {
-                      window._gaq = window._gaq || [];
-
-                      if(testMode !== true) {
-                          window._gaq.push(['_setAccount', forwarderSettings.apiKey]);
-
-                          if (forwarderSettings.useLocalhostCookie == 'True') {
-                              window._gaq.push(['_setDomainName', 'none']);
-                          }
-
-                          (function() {
-                              var ga = document.createElement('script'); ga.type = 'text/javascript'; ga.async = true;
-                              if (forwarderSettings.useDisplayFeatures == 'True') {
-                                  ga.src = ('https:' == document.location.protocol ? 'https://' : 'http://') + 'stats.g.doubleclick.net/dc.js';
-                              } else {
-                                  ga.src = ('https:' == document.location.protocol ? 'https://ssl' : 'http://www') + '.google-analytics.com/ga.js';
-                              }
-                              var s = document.getElementsByTagName('script')[0]; s.parentNode.insertBefore(ga, s);
-                          })();
-                      }
-                  }
-                  else {
-                      if(testMode !== true) {
-                          (function(i, s, o, g, r, a, m) {
-                              i['GoogleAnalyticsObject'] = r; i[r] = i[r] || function() {
-                                  (i[r].q = i[r].q || []).push(arguments);
-                              }, i[r].l = 1 * new Date(); a = s.createElement(o),
-                              m = s.getElementsByTagName(o)[0]; a.async = 1; a.src = g; m.parentNode.insertBefore(a, m);
-                          })(window, document, 'script', '//www.google-analytics.com/analytics.js', 'ga');
-                      }
-
-                      var fieldsObject = {
-                          trackingId:forwarderSettings.apiKey,
-                          name: trackerId
-                      };
-
-                      if (forwarderSettings.useLocalhostCookie == 'True') {
-                          fieldsObject.cookieDomain = 'none';
-                      }
-
-                      if (forwarderSettings.clientIdentificationType === 'AMP') {
-                          fieldsObject.useAmpClientId = true;
-                      }
-
-                      ga('create', fieldsObject);
-
-                      if (forwarderSettings.useDisplayFeatures == 'True') {
-                          ga(createCmd('require'), 'displayfeatures');
-                      }
-
-                      if (forwarderSettings.useSecure == 'True') {
-                          ga(createCmd('set'), 'forceSSL', true);
-                      }
-                      if (forwarderSettings.customDimensions) {
-                          var customDimensions = JSON.parse(forwarderSettings.customDimensions.replace(/&quot;/g, '\"'));
-                          customDimensions.forEach(function(dimension) {
-                              if (dimension.maptype === 'EventAttributeClass.Name') {
-                                  checkForDuplicateMapping(dimension, eventLevelMap);
-                                  eventLevelMap['customDimensions'][formatDimensionOrMetric(dimension.value)] = dimension.map;
-                              } else if (dimension.maptype === 'UserAttributeClass.Name') {
-                                  checkForDuplicateMapping(dimension, userLevelMap);
-                                  userLevelMap['customDimensions'][formatDimensionOrMetric(dimension.value)] = dimension.map;
-                              } else if (dimension.maptype === 'ProductAttributeSelector.Name') {
-                                  checkForDuplicateMapping(dimension, productLevelMap);
-                                  productLevelMap['customDimensions'][formatDimensionOrMetric(dimension.value)] = dimension.map;
-                              }
-                          });
-                      }
-
-                      if (forwarderSettings.customMetrics) {
-                          var customMetrics = JSON.parse(forwarderSettings.customMetrics.replace(/&quot;/g, '\"'));
-                          customMetrics.forEach(function(metric) {
-                              if (metric.maptype === 'EventAttributeClass.Name') {
-                                  checkForDuplicateMapping(metric, eventLevelMap);
-                                  eventLevelMap['customMetrics'][formatDimensionOrMetric(metric.value)] = metric.map;
-                              } else if (metric.maptype === 'UserAttributeClass.Name') {
-                                  checkForDuplicateMapping(metric, userLevelMap);
-                                  userLevelMap['customMetrics'][formatDimensionOrMetric(metric.value)] = metric.map;
-                              } else if (metric.maptype === 'ProductAttributeSelector.Name') {
-                                  checkForDuplicateMapping(metric, productLevelMap);
-                                  productLevelMap['customMetrics'][formatDimensionOrMetric(metric.value)] = metric.map;
-                              }
-                          });
-                      }
-                  }
-
-                  isInitialized = true;
-                  return 'Successfully initialized: ' + name;
-              }
-              catch (e) {
-                  return 'Failed to initialize: ' + name;
-              }
-          }
-
-          this.init = initForwarder;
-          this.process = processEvent;
-          this.setUserIdentity = setUserIdentity;
-      };
-
-      function getId() {
-          return moduleId;
-      }
-
-      function register(config) {
-          if (!config) {
-              window.console.log('You must pass a config object to register the kit ' + name);
-              return;
-          }
-
-          if (!isObject(config)) {
-              window.console.log('\'config\' must be an object. You passed in a ' + typeof config);
-              return;
-          }
-
-          if (isObject(config.kits)) {
-              config.kits[name] = {
-                  constructor: constructor
-              };
-          } else {
-              config.kits = {};
-              config.kits[name] = {
-                  constructor: constructor
-              };
-          }
-          window.console.log('Successfully registered ' + name + ' to your mParticle configuration');
-      }
-
-      if (window && window.mParticle && window.mParticle.addForwarder) {
-          window.mParticle.addForwarder({
-              name: name,
-              constructor: constructor,
-              getId: getId
-          });
-      }
-
-      var GoogleAnalyticsEventForwarder = {
-          register: register
-      };
-  var GoogleAnalyticsEventForwarder_1 = GoogleAnalyticsEventForwarder.register;
-
-  exports.default = GoogleAnalyticsEventForwarder;
-  exports.register = GoogleAnalyticsEventForwarder_1;
-
-  return exports;
+    /* eslint-disable no-undef*/
+    //
+    //  Copyright 2019 mParticle, Inc.
+    //
+    //  Licensed under the Apache License, Version 2.0 (the "License");
+    //  you may not use this file except in compliance with the License.
+    //  You may obtain a copy of the License at
+    //
+    //      http://www.apache.org/licenses/LICENSE-2.0
+    //
+    //  Unless required by applicable law or agreed to in writing, software
+    //  distributed under the License is distributed on an "AS IS" BASIS,
+    //  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    //  See the License for the specific language governing permissions and
+    //  limitations under the License.
+
+        var name = 'GoogleAnalyticsEventForwarder',
+            moduleId = 6,
+            MessageType = {
+                SessionStart: 1,
+                SessionEnd: 2,
+                PageView: 3,
+                PageEvent: 4,
+                CrashReport: 5,
+                OptOut: 6,
+                Commerce: 16
+            },
+            trackerCount = 1,
+            NON_INTERACTION_FLAG = 'Google.NonInteraction',
+            CATEGORY = 'Google.Category',
+            LABEL = 'Google.Label',
+            PAGE = 'Google.Page',
+            VALUE = 'Google.Value',
+            HITTYPE = 'Google.HitType';
+
+        var constructor = function() {
+            var self = this,
+                isInitialized = false,
+                isEnhancedEcommerceLoaded = false,
+                forwarderSettings,
+                reportingService,
+                trackerId = null,
+                eventLevelMap = {
+                    customDimensions: {},
+                    customMetrics: {}
+                },
+                userLevelMap = {
+                    customDimensions: {},
+                    customMetrics: {}
+                },
+                productLevelMap = {
+                    customDimensions: {},
+                    customMetrics: {}
+                };
+
+            self.name = name;
+
+            function createTrackerId() {
+                return 'mpgaTracker' + trackerCount++;
+            }
+
+            function createCmd(cmd) {
+                // Prepends the specified command with the tracker id
+                return trackerId + '.' + cmd;
+            }
+
+            function getEventTypeName(eventType) {
+                return mParticle.EventType.getName(eventType);
+            }
+
+            function formatDimensionOrMetric(attr) {
+                return attr.replace(/ /g, '').toLowerCase();
+            }
+
+            function applyCustomDimensionsAndMetrics(event, outputDimensionsAndMetrics) {
+                // apply custom dimensions and metrics to each event, product, or user if respective attributes exist
+                if (event.EventAttributes && Object.keys(event.EventAttributes).length) {
+                    applyCustomDimensionsMetricsForSourceAttributes(event.EventAttributes, outputDimensionsAndMetrics, eventLevelMap);
+                }
+
+                if (event.UserAttributes && Object.keys(event.UserAttributes).length) {
+                    applyCustomDimensionsMetricsForSourceAttributes(event.UserAttributes, outputDimensionsAndMetrics, userLevelMap);
+                }
+            }
+
+            function applyCustomDimensionsMetricsForSourceAttributes(attributes, targetDimensionsAndMetrics, mapLevel) {
+                for (var customDimension in mapLevel.customDimensions) {
+                    for (attrName in attributes) {
+                        if (customDimension === attrName) {
+                            targetDimensionsAndMetrics[mapLevel.customDimensions[customDimension]] = attributes[attrName];
+                        }
+                    }
+                }
+
+                for (var customMetric in mapLevel.customMetrics) {
+                    for (attrName in attributes) {
+                        if (customMetric === attrName) {
+                            targetDimensionsAndMetrics[mapLevel.customMetrics[customMetric]] = attributes[attrName];
+                        }
+                    }
+                }
+            }
+
+            function applyCustomFlags(flags, outputDimensionsAndMetrics) {
+                if (flags.hasOwnProperty(NON_INTERACTION_FLAG)) {
+                    outputDimensionsAndMetrics['nonInteraction'] = flags[NON_INTERACTION_FLAG];
+                }
+            }
+
+            function processEvent(event) {
+                var outputDimensionsAndMetrics = {};
+                var reportEvent = false;
+
+                if (isInitialized) {
+                    event.ExpandedEventCount = 0;
+
+                    applyCustomDimensionsAndMetrics(event, outputDimensionsAndMetrics);
+
+                    if (event.CustomFlags && Object.keys(event.CustomFlags).length) {
+                        applyCustomFlags(event.CustomFlags, outputDimensionsAndMetrics);
+                    }
+
+                    try {
+                        if (event.EventDataType == MessageType.PageView) {
+                            logPageView(event, outputDimensionsAndMetrics, event.CustomFlags);
+                            reportEvent = true;
+                        }
+                        else if (event.EventDataType == MessageType.Commerce) {
+                            logCommerce(event, outputDimensionsAndMetrics, event.CustomFlags);
+                            reportEvent = true;
+                        }
+                        else if (event.EventDataType == MessageType.PageEvent) {
+                            reportEvent = true;
+
+                            logEvent(event, outputDimensionsAndMetrics, event.CustomFlags);
+                        }
+
+                        if (reportEvent && reportingService) {
+                            reportingService(self, event);
+                        }
+
+                        return 'Successfully sent to ' + name;
+                    }
+                    catch (e) {
+                        return 'Failed to send to: ' + name + ' ' + e;
+                    }
+                }
+
+                return 'Can\'t send to forwarder ' + name + ', not initialized';
+            }
+
+            function setUserIdentity(id, type) {
+                if (isInitialized) {
+                    if (forwarderSettings.useCustomerId == 'True' && type == window.mParticle.IdentityType.CustomerId) {
+                        if (forwarderSettings.classicMode == 'True') ;
+                        else {
+                            ga(createCmd('set'), 'userId', window.mParticle.generateHash(id));
+                        }
+                    }
+                }
+                else {
+                    return 'Can\'t call setUserIdentity on forwarder ' + name + ', not initialized';
+                }
+            }
+
+            function addEcommerceProduct(product, updatedProductDimentionAndMetrics) {
+                var productAttrs = {
+                    id: product.Sku,
+                    name: product.Name,
+                    category: product.Category,
+                    brand: product.Brand,
+                    variant: product.Variant,
+                    price: product.Price,
+                    coupon: product.CouponCode,
+                    quantity: product.Quantity
+                };
+
+                for (var attr in updatedProductDimentionAndMetrics) {
+                    if (updatedProductDimentionAndMetrics.hasOwnProperty(attr)) {
+                        productAttrs[attr] = updatedProductDimentionAndMetrics[attr];
+                    }
+                }
+
+                ga(createCmd('ec:addProduct'), productAttrs);
+            }
+
+            function addEcommerceProductImpression(product) {
+                ga(createCmd('ec:addImpression'), {
+                    id: product.Sku,
+                    name: product.Name,
+                    type: 'view',
+                    category: product.Category,
+                    brand: product.Brand,
+                    variant: product.Variant
+                });
+            }
+
+            function sendEcommerceEvent(type, outputDimensionsAndMetrics, customFlags) {
+                ga(createCmd('send'), customFlags && customFlags[HITTYPE] ? customFlags[HITTYPE] : 'event', 'eCommerce', getEventTypeName(type), outputDimensionsAndMetrics);
+            }
+
+            function logCommerce(data, outputDimensionsAndMetrics, customFlags) {
+                if (!isEnhancedEcommerceLoaded) {
+                    ga(createCmd('require'), 'ec');
+                    isEnhancedEcommerceLoaded = true;
+                }
+
+                if (data.CurrencyCode) {
+                    // Set currency code if present
+                    ga(createCmd('set'), '&cu', data.CurrencyCode);
+                }
+
+                if (data.ProductImpressions) {
+                    // Impression event
+                    data.ProductImpressions.forEach(function(impression) {
+                        impression.ProductList.forEach(function(product) {
+                            addEcommerceProductImpression(product);
+                        });
+                    });
+
+                    sendEcommerceEvent(data.EventCategory, outputDimensionsAndMetrics, customFlags);
+                }
+                else if (data.PromotionAction) {
+                    // Promotion event
+                    data.PromotionAction.PromotionList.forEach(function(promotion) {
+                        ga(createCmd('ec:addPromo'), {
+                            id: promotion.Id,
+                            name: promotion.Name,
+                            creative: promotion.Creative,
+                            position: promotion.Position
+                        });
+                    });
+
+                    if (data.PromotionAction.PromotionActionType == mParticle.PromotionType.PromotionClick) {
+                        ga(createCmd('ec:setAction'), 'promo_click');
+                    }
+
+                    sendEcommerceEvent(data.EventDataType, outputDimensionsAndMetrics, customFlags);
+                }
+                else if (data.ProductAction) {
+                    if (data.ProductAction.ProductActionType == mParticle.ProductActionType.Purchase) {
+                        data.ProductAction.ProductList.forEach(function(product) {
+                            var updatedProductDimentionAndMetrics = {};
+                            applyCustomDimensionsMetricsForSourceAttributes(product.Attributes, updatedProductDimentionAndMetrics, productLevelMap);
+                            addEcommerceProduct(product, updatedProductDimentionAndMetrics);
+                        });
+
+                        ga(createCmd('ec:setAction'), 'purchase', {
+                            id: data.ProductAction.TransactionId,
+                            affiliation: data.ProductAction.Affiliation,
+                            revenue: data.ProductAction.TotalAmount,
+                            tax: data.ProductAction.TaxAmount,
+                            shipping: data.ProductAction.ShippingAmount,
+                            coupon: data.ProductAction.CouponCode
+                        });
+
+                        sendEcommerceEvent(data.EventDataType, outputDimensionsAndMetrics, customFlags);
+                    }
+                    else if (data.ProductAction.ProductActionType == mParticle.ProductActionType.Refund) {
+                        if (data.ProductAction.ProductList.length) {
+                            data.ProductAction.ProductList.forEach(function(product) {
+                                var productAttrs = {
+                                    id: product.Sku,
+                                    quantity: product.Quantity
+                                };
+                                applyCustomDimensionsMetricsForSourceAttributes(product.Attributes, productAttrs, productLevelMap);
+                                ga(createCmd('ec:addProduct'), productAttrs);
+                            });
+                        }
+
+                        ga(createCmd('ec:setAction'), 'refund', {
+                            id: data.ProductAction.TransactionId
+                        });
+
+                        sendEcommerceEvent(data.EventDataType, outputDimensionsAndMetrics, customFlags);
+                    }
+                    else if (data.ProductAction.ProductActionType == mParticle.ProductActionType.AddToCart ||
+                        data.ProductAction.ProductActionType == mParticle.ProductActionType.RemoveFromCart) {
+                        var updatedProductDimentionAndMetrics = {};
+                        data.ProductAction.ProductList.forEach(function(product) {
+                            applyCustomDimensionsMetricsForSourceAttributes(product.Attributes, updatedProductDimentionAndMetrics, productLevelMap);
+                            addEcommerceProduct(product, updatedProductDimentionAndMetrics);
+                        });
+
+                        ga(createCmd('ec:setAction'),
+                            data.ProductAction.ProductActionType == mParticle.ProductActionType.AddToCart ? 'add' : 'remove');
+
+                        sendEcommerceEvent(data.EventDataType, outputDimensionsAndMetrics, customFlags);
+                    }
+                    else if (data.ProductAction.ProductActionType == mParticle.ProductActionType.Checkout) {
+                        data.ProductAction.ProductList.forEach(function(product) {
+                            var updatedProductDimentionAndMetrics = {};
+                            applyCustomDimensionsMetricsForSourceAttributes(product.Attributes, updatedProductDimentionAndMetrics, productLevelMap);
+                            addEcommerceProduct(product, updatedProductDimentionAndMetrics);
+                        });
+
+                        ga(createCmd('ec:setAction'), 'checkout', {
+                            step: data.ProductAction.CheckoutStep,
+                            option: data.ProductAction.CheckoutOptions
+                        });
+
+                        sendEcommerceEvent(data.EventDataType, outputDimensionsAndMetrics, customFlags);
+                    }
+                    else if (data.ProductAction.ProductActionType == mParticle.ProductActionType.Click) {
+                        data.ProductAction.ProductList.forEach(function(product) {
+                            var updatedProductDimentionAndMetrics = {};
+                            applyCustomDimensionsMetricsForSourceAttributes(product.Attributes, updatedProductDimentionAndMetrics, productLevelMap);
+                            addEcommerceProduct(product, updatedProductDimentionAndMetrics);
+                        });
+
+                        ga(createCmd('ec:setAction'), 'click');
+                        sendEcommerceEvent(data.EventDataType, outputDimensionsAndMetrics, customFlags);
+                    }
+                    else if (data.ProductAction.ProductActionType == mParticle.ProductActionType.ViewDetail) {
+                        data.ProductAction.ProductList.forEach(function(product) {
+                            var updatedProductDimentionAndMetrics = {};
+                            applyCustomDimensionsMetricsForSourceAttributes(product.Attributes, updatedProductDimentionAndMetrics, productLevelMap);
+                            addEcommerceProduct(product );
+                        });
+
+                        ga(createCmd('ec:setAction'), 'detail');
+                        ga(createCmd('send'), customFlags && customFlags[HITTYPE] ? customFlags[HITTYPE] : 'event', 'eCommerce', getEventTypeName(data.EventCategory), outputDimensionsAndMetrics);
+                    }
+                }
+            }
+
+            function logPageView(event, outputDimensionsAndMetrics, customFlags) {
+                if (forwarderSettings.classicMode == 'True') {
+                    _gaq.push(['_trackPageview']);
+                }
+                else {
+                    if (event.CustomFlags && event.CustomFlags[PAGE]) {
+                        ga(createCmd('set'), 'page', event.CustomFlags[PAGE]);
+                    }
+                    ga(createCmd('send'), customFlags && customFlags[HITTYPE] ? customFlags[HITTYPE] : 'pageview', outputDimensionsAndMetrics);
+                }
+            }
+
+            function logEvent(data, outputDimensionsAndMetrics, customFlags) {
+                var label = '',
+                    category = getEventTypeName(data.EventCategory),
+                    value;
+
+                if (data.EventAttributes) {
+                    if (data.EventAttributes.label) {
+                        label = data.EventAttributes.label;
+                    }
+
+                    if (data.EventAttributes.value) {
+                        value = parseInt(data.EventAttributes.value, 10);
+
+                        // Test for NaN
+                        if (value != value) {
+                            value = null;
+                        }
+                    }
+
+                    if (data.EventAttributes.category) {
+                        category = data.EventAttributes.category;
+                    }
+                }
+
+                if(data.CustomFlags) {
+                    var googleCategory = data.CustomFlags[CATEGORY],
+                        googleLabel = data.CustomFlags[LABEL],
+                        googleValue = parseInt(data.CustomFlags[VALUE], 10);
+
+                    if (googleCategory) {
+                        category = googleCategory;
+                    }
+
+                    if (googleLabel) {
+                        label = googleLabel;
+                    }
+
+                    // Ensure not NaN
+                    if (googleValue == googleValue) {
+                        value = googleValue;
+                    }
+                }
+
+                if (forwarderSettings.classicMode == 'True') {
+                    _gaq.push(['_trackEvent',
+                        category,
+                        data.EventName,
+                        label,
+                        value]);
+                }
+                else {
+                    ga(createCmd('send'),
+                        customFlags && customFlags[HITTYPE] ? customFlags[HITTYPE] : 'event',
+                        category,
+                        data.EventName,
+                        label,
+                        value,
+                        outputDimensionsAndMetrics);
+                }
+            }
+
+            function initForwarder(settings, service, testMode, tid) {
+                try {
+                    forwarderSettings = settings;
+                    reportingService = service;
+                    isTesting = testMode;
+
+                    if (!tid) {
+                        trackerId = createTrackerId();
+                    }
+                    else {
+                        trackerId = tid;
+                    }
+
+                    if (forwarderSettings.classicMode == 'True') {
+                        window._gaq = window._gaq || [];
+
+                        if(testMode !== true) {
+                            window._gaq.push(['_setAccount', forwarderSettings.apiKey]);
+
+                            if (forwarderSettings.useLocalhostCookie == 'True') {
+                                window._gaq.push(['_setDomainName', 'none']);
+                            }
+
+                            (function() {
+                                var ga = document.createElement('script'); ga.type = 'text/javascript'; ga.async = true;
+                                if (forwarderSettings.useDisplayFeatures == 'True') {
+                                    ga.src = ('https:' == document.location.protocol ? 'https://' : 'http://') + 'stats.g.doubleclick.net/dc.js';
+                                } else {
+                                    ga.src = ('https:' == document.location.protocol ? 'https://ssl' : 'http://www') + '.google-analytics.com/ga.js';
+                                }
+                                var s = document.getElementsByTagName('script')[0]; s.parentNode.insertBefore(ga, s);
+                            })();
+                        }
+                    }
+                    else {
+                        if(testMode !== true) {
+                            (function(i, s, o, g, r, a, m) {
+                                i['GoogleAnalyticsObject'] = r; i[r] = i[r] || function() {
+                                    (i[r].q = i[r].q || []).push(arguments);
+                                }, i[r].l = 1 * new Date(); a = s.createElement(o),
+                                m = s.getElementsByTagName(o)[0]; a.async = 1; a.src = g; m.parentNode.insertBefore(a, m);
+                            })(window, document, 'script', '//www.google-analytics.com/analytics.js', 'ga');
+                        }
+
+                        var fieldsObject = {
+                            trackingId:forwarderSettings.apiKey,
+                            name: trackerId
+                        };
+
+                        if (forwarderSettings.useLocalhostCookie == 'True') {
+                            fieldsObject.cookieDomain = 'none';
+                        }
+
+                        if (forwarderSettings.clientIdentificationType === 'AMP') {
+                            fieldsObject.useAmpClientId = true;
+                        }
+
+                        ga('create', fieldsObject);
+
+                        if (forwarderSettings.useDisplayFeatures == 'True') {
+                            ga(createCmd('require'), 'displayfeatures');
+                        }
+
+                        if (forwarderSettings.useSecure == 'True') {
+                            ga(createCmd('set'), 'forceSSL', true);
+                        }
+                        if (forwarderSettings.customDimensions) {
+                            var customDimensions = JSON.parse(forwarderSettings.customDimensions.replace(/&quot;/g, '\"'));
+                            customDimensions.forEach(function(dimension) {
+                                if (dimension.maptype === 'EventAttributeClass.Name') {
+                                    eventLevelMap['customDimensions'][dimension.map] = formatDimensionOrMetric(dimension.value);
+                                } else if (dimension.maptype === 'UserAttributeClass.Name') {
+                                    userLevelMap['customDimensions'][dimension.map] = formatDimensionOrMetric(dimension.value);
+                                } else if (dimension.maptype === 'ProductAttributeSelector.Name') {
+                                    productLevelMap['customDimensions'][dimension.map] = formatDimensionOrMetric(dimension.value);
+                                }
+                            });
+                        }
+
+                        if (forwarderSettings.customMetrics) {
+                            var customMetrics = JSON.parse(forwarderSettings.customMetrics.replace(/&quot;/g, '\"'));
+                            customMetrics.forEach(function(metric) {
+                                if (metric.maptype === 'EventAttributeClass.Name') {
+                                    eventLevelMap['customMetrics'][metric.map] = formatDimensionOrMetric(metric.value);
+                                } else if (metric.maptype === 'UserAttributeClass.Name') {
+                                    userLevelMap['customMetrics'][metric.map] = formatDimensionOrMetric(metric.value);
+                                } else if (metric.maptype === 'ProductAttributeSelector.Name') {
+                                    productLevelMap['customMetrics'][metric.map] = formatDimensionOrMetric(metric.value);
+                                }
+                            });
+                        }
+                    }
+
+                    isInitialized = true;
+                    return 'Successfully initialized: ' + name;
+                }
+                catch (e) {
+                    return 'Failed to initialize: ' + name;
+                }
+            }
+
+            this.init = initForwarder;
+            this.process = processEvent;
+            this.setUserIdentity = setUserIdentity;
+        };
+
+        function getId() {
+            return moduleId;
+        }
+
+        function isObject(val) {
+            return val != null && typeof val === 'object' && Array.isArray(val) === false;
+        }
+
+        function register(config) {
+            if (!config) {
+                window.console.log('You must pass a config object to register the kit ' + name);
+                return;
+            }
+
+            if (!isObject(config)) {
+                window.console.log('\'config\' must be an object. You passed in a ' + typeof config);
+                return;
+            }
+
+            if (isObject(config.kits)) {
+                config.kits[name] = {
+                    constructor: constructor
+                };
+            } else {
+                config.kits = {};
+                config.kits[name] = {
+                    constructor: constructor
+                };
+            }
+            window.console.log('Successfully registered ' + name + ' to your mParticle configuration');
+        }
+
+        if (window && window.mParticle && window.mParticle.addForwarder) {
+            window.mParticle.addForwarder({
+                name: name,
+                constructor: constructor,
+                getId: getId
+            });
+        }
+
+        var GoogleAnalyticsEventForwarder = {
+            register: register
+        };
+    var GoogleAnalyticsEventForwarder_1 = GoogleAnalyticsEventForwarder.register;
+
+    exports.default = GoogleAnalyticsEventForwarder;
+    exports.register = GoogleAnalyticsEventForwarder_1;
+
+    return exports;
 
 }({}));

--- a/dist/GoogleAnalyticsEventForwarder.common.js
+++ b/dist/GoogleAnalyticsEventForwarder.common.js
@@ -1,16 +1,5 @@
 Object.defineProperty(exports, '__esModule', { value: true });
 
-/*!
- * isobject <https://github.com/jonschlinkert/isobject>
- *
- * Copyright (c) 2014-2017, Jon Schlinkert.
- * Released under the MIT License.
- */
-
-function isObject(val) {
-  return val != null && typeof val === 'object' && Array.isArray(val) === false;
-}
-
 /* eslint-disable no-undef*/
 //
 //  Copyright 2019 mParticle, Inc.
@@ -26,8 +15,6 @@ function isObject(val) {
 //  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 //  See the License for the specific language governing permissions and
 //  limitations under the License.
-
-    
 
     var name = 'GoogleAnalyticsEventForwarder',
         moduleId = 6,
@@ -99,18 +86,18 @@ function isObject(val) {
         }
 
         function applyCustomDimensionsMetricsForSourceAttributes(attributes, targetDimensionsAndMetrics, mapLevel) {
-            for (var cdKey in mapLevel.customDimensions) {
+            for (var customDimension in mapLevel.customDimensions) {
                 for (attrName in attributes) {
-                    if (mapLevel.customDimensions[cdKey] === attrName) {
-                        targetDimensionsAndMetrics[cdKey] = attributes[attrName];
+                    if (customDimension === attrName) {
+                        targetDimensionsAndMetrics[mapLevel.customDimensions[customDimension]] = attributes[attrName];
                     }
                 }
             }
 
-            for (var cmKey in mapLevel.customMetrics) {
+            for (var customMetric in mapLevel.customMetrics) {
                 for (attrName in attributes) {
-                    if (mapLevel.customMetrics[cmKey] === attrName) {
-                        targetDimensionsAndMetrics[cmKey] = attributes[attrName];
+                    if (customMetric === attrName) {
+                        targetDimensionsAndMetrics[mapLevel.customMetrics[customMetric]] = attributes[attrName];
                     }
                 }
             }
@@ -412,13 +399,6 @@ function isObject(val) {
             }
         }
 
-        function checkForDuplicateMapping(dimensionOrMetric, eventLevelMap) {
-            var existingMapper = eventLevelMap['customDimensions'][formatDimensionOrMetric(dimensionOrMetric.value)];
-            if (existingMapper) {
-                console.log('Warning: both ' + existingMapper + ' & ' + dimensionOrMetric.map + ' are mapped to ' + dimensionOrMetric.value + '. ' + dimensionOrMetric.map + ' is replacing ' + existingMapper + '. If this is a mistake, please revisit the Google Analytics settings at app.mparticle.com. Otherwise, please ignore this warning.');
-            }
-        }
-
         function initForwarder(settings, service, testMode, tid) {
             try {
                 forwarderSettings = settings;
@@ -489,14 +469,11 @@ function isObject(val) {
                         var customDimensions = JSON.parse(forwarderSettings.customDimensions.replace(/&quot;/g, '\"'));
                         customDimensions.forEach(function(dimension) {
                             if (dimension.maptype === 'EventAttributeClass.Name') {
-                                checkForDuplicateMapping(dimension, eventLevelMap);
-                                eventLevelMap['customDimensions'][formatDimensionOrMetric(dimension.value)] = dimension.map;
+                                eventLevelMap['customDimensions'][dimension.map] = formatDimensionOrMetric(dimension.value);
                             } else if (dimension.maptype === 'UserAttributeClass.Name') {
-                                checkForDuplicateMapping(dimension, userLevelMap);
-                                userLevelMap['customDimensions'][formatDimensionOrMetric(dimension.value)] = dimension.map;
+                                userLevelMap['customDimensions'][dimension.map] = formatDimensionOrMetric(dimension.value);
                             } else if (dimension.maptype === 'ProductAttributeSelector.Name') {
-                                checkForDuplicateMapping(dimension, productLevelMap);
-                                productLevelMap['customDimensions'][formatDimensionOrMetric(dimension.value)] = dimension.map;
+                                productLevelMap['customDimensions'][dimension.map] = formatDimensionOrMetric(dimension.value);
                             }
                         });
                     }
@@ -505,14 +482,11 @@ function isObject(val) {
                         var customMetrics = JSON.parse(forwarderSettings.customMetrics.replace(/&quot;/g, '\"'));
                         customMetrics.forEach(function(metric) {
                             if (metric.maptype === 'EventAttributeClass.Name') {
-                                checkForDuplicateMapping(metric, eventLevelMap);
-                                eventLevelMap['customMetrics'][formatDimensionOrMetric(metric.value)] = metric.map;
+                                eventLevelMap['customMetrics'][metric.map] = formatDimensionOrMetric(metric.value);
                             } else if (metric.maptype === 'UserAttributeClass.Name') {
-                                checkForDuplicateMapping(metric, userLevelMap);
-                                userLevelMap['customMetrics'][formatDimensionOrMetric(metric.value)] = metric.map;
+                                userLevelMap['customMetrics'][metric.map] = formatDimensionOrMetric(metric.value);
                             } else if (metric.maptype === 'ProductAttributeSelector.Name') {
-                                checkForDuplicateMapping(metric, productLevelMap);
-                                productLevelMap['customMetrics'][formatDimensionOrMetric(metric.value)] = metric.map;
+                                productLevelMap['customMetrics'][metric.map] = formatDimensionOrMetric(metric.value);
                             }
                         });
                     }
@@ -533,6 +507,10 @@ function isObject(val) {
 
     function getId() {
         return moduleId;
+    }
+
+    function isObject(val) {
+        return val != null && typeof val === 'object' && Array.isArray(val) === false;
     }
 
     function register(config) {

--- a/dist/GoogleAnalyticsEventForwarder.common.js
+++ b/dist/GoogleAnalyticsEventForwarder.common.js
@@ -18,6 +18,7 @@ Object.defineProperty(exports, '__esModule', { value: true });
 
     var name = 'GoogleAnalyticsEventForwarder',
         moduleId = 6,
+        version = '2.0.1',
         MessageType = {
             SessionStart: 1,
             SessionEnd: 2,
@@ -546,9 +547,14 @@ Object.defineProperty(exports, '__esModule', { value: true });
     }
 
     var GoogleAnalyticsEventForwarder = {
-        register: register
+        register: register,
+        getVersion: function() {
+            return version;
+        }
     };
 var GoogleAnalyticsEventForwarder_1 = GoogleAnalyticsEventForwarder.register;
+var GoogleAnalyticsEventForwarder_2 = GoogleAnalyticsEventForwarder.getVersion;
 
 exports.default = GoogleAnalyticsEventForwarder;
+exports.getVersion = GoogleAnalyticsEventForwarder_2;
 exports.register = GoogleAnalyticsEventForwarder_1;

--- a/dist/GoogleAnalyticsEventForwarder.iife.js
+++ b/dist/GoogleAnalyticsEventForwarder.iife.js
@@ -17,6 +17,7 @@ var mpGoogleAnalyticsKit = (function (exports) {
 
         var name = 'GoogleAnalyticsEventForwarder',
             moduleId = 6,
+            version = '2.0.1',
             MessageType = {
                 SessionStart: 1,
                 SessionEnd: 2,
@@ -545,11 +546,16 @@ var mpGoogleAnalyticsKit = (function (exports) {
         }
 
         var GoogleAnalyticsEventForwarder = {
-            register: register
+            register: register,
+            getVersion: function() {
+                return version;
+            }
         };
     var GoogleAnalyticsEventForwarder_1 = GoogleAnalyticsEventForwarder.register;
+    var GoogleAnalyticsEventForwarder_2 = GoogleAnalyticsEventForwarder.getVersion;
 
     exports.default = GoogleAnalyticsEventForwarder;
+    exports.getVersion = GoogleAnalyticsEventForwarder_2;
     exports.register = GoogleAnalyticsEventForwarder_1;
 
     return exports;

--- a/dist/GoogleAnalyticsEventForwarder.iife.js
+++ b/dist/GoogleAnalyticsEventForwarder.iife.js
@@ -1,579 +1,557 @@
 var mpGoogleAnalyticsKit = (function (exports) {
-  /*!
-   * isobject <https://github.com/jonschlinkert/isobject>
-   *
-   * Copyright (c) 2014-2017, Jon Schlinkert.
-   * Released under the MIT License.
-   */
-
-  function isObject(val) {
-    return val != null && typeof val === 'object' && Array.isArray(val) === false;
-  }
-
-  /* eslint-disable no-undef*/
-  //
-  //  Copyright 2019 mParticle, Inc.
-  //
-  //  Licensed under the Apache License, Version 2.0 (the "License");
-  //  you may not use this file except in compliance with the License.
-  //  You may obtain a copy of the License at
-  //
-  //      http://www.apache.org/licenses/LICENSE-2.0
-  //
-  //  Unless required by applicable law or agreed to in writing, software
-  //  distributed under the License is distributed on an "AS IS" BASIS,
-  //  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-  //  See the License for the specific language governing permissions and
-  //  limitations under the License.
-
-      
-
-      var name = 'GoogleAnalyticsEventForwarder',
-          moduleId = 6,
-          MessageType = {
-              SessionStart: 1,
-              SessionEnd: 2,
-              PageView: 3,
-              PageEvent: 4,
-              CrashReport: 5,
-              OptOut: 6,
-              Commerce: 16
-          },
-          trackerCount = 1,
-          NON_INTERACTION_FLAG = 'Google.NonInteraction',
-          CATEGORY = 'Google.Category',
-          LABEL = 'Google.Label',
-          PAGE = 'Google.Page',
-          VALUE = 'Google.Value',
-          HITTYPE = 'Google.HitType';
-
-      var constructor = function() {
-          var self = this,
-              isInitialized = false,
-              isEnhancedEcommerceLoaded = false,
-              forwarderSettings,
-              reportingService,
-              trackerId = null,
-              eventLevelMap = {
-                  customDimensions: {},
-                  customMetrics: {}
-              },
-              userLevelMap = {
-                  customDimensions: {},
-                  customMetrics: {}
-              },
-              productLevelMap = {
-                  customDimensions: {},
-                  customMetrics: {}
-              };
-
-          self.name = name;
-
-          function createTrackerId() {
-              return 'mpgaTracker' + trackerCount++;
-          }
-
-          function createCmd(cmd) {
-              // Prepends the specified command with the tracker id
-              return trackerId + '.' + cmd;
-          }
-
-          function getEventTypeName(eventType) {
-              return mParticle.EventType.getName(eventType);
-          }
-
-          function formatDimensionOrMetric(attr) {
-              return attr.replace(/ /g, '').toLowerCase();
-          }
-
-          function applyCustomDimensionsAndMetrics(event, outputDimensionsAndMetrics) {
-              // apply custom dimensions and metrics to each event, product, or user if respective attributes exist
-              if (event.EventAttributes && Object.keys(event.EventAttributes).length) {
-                  applyCustomDimensionsMetricsForSourceAttributes(event.EventAttributes, outputDimensionsAndMetrics, eventLevelMap);
-              }
-
-              if (event.UserAttributes && Object.keys(event.UserAttributes).length) {
-                  applyCustomDimensionsMetricsForSourceAttributes(event.UserAttributes, outputDimensionsAndMetrics, userLevelMap);
-              }
-          }
-
-          function applyCustomDimensionsMetricsForSourceAttributes(attributes, targetDimensionsAndMetrics, mapLevel) {
-              for (var cdKey in mapLevel.customDimensions) {
-                  for (attrName in attributes) {
-                      if (mapLevel.customDimensions[cdKey] === attrName) {
-                          targetDimensionsAndMetrics[cdKey] = attributes[attrName];
-                      }
-                  }
-              }
-
-              for (var cmKey in mapLevel.customMetrics) {
-                  for (attrName in attributes) {
-                      if (mapLevel.customMetrics[cmKey] === attrName) {
-                          targetDimensionsAndMetrics[cmKey] = attributes[attrName];
-                      }
-                  }
-              }
-          }
-
-          function applyCustomFlags(flags, outputDimensionsAndMetrics) {
-              if (flags.hasOwnProperty(NON_INTERACTION_FLAG)) {
-                  outputDimensionsAndMetrics['nonInteraction'] = flags[NON_INTERACTION_FLAG];
-              }
-          }
-
-          function processEvent(event) {
-              var outputDimensionsAndMetrics = {};
-              var reportEvent = false;
-
-              if (isInitialized) {
-                  event.ExpandedEventCount = 0;
-
-                  applyCustomDimensionsAndMetrics(event, outputDimensionsAndMetrics);
-
-                  if (event.CustomFlags && Object.keys(event.CustomFlags).length) {
-                      applyCustomFlags(event.CustomFlags, outputDimensionsAndMetrics);
-                  }
-
-                  try {
-                      if (event.EventDataType == MessageType.PageView) {
-                          logPageView(event, outputDimensionsAndMetrics, event.CustomFlags);
-                          reportEvent = true;
-                      }
-                      else if (event.EventDataType == MessageType.Commerce) {
-                          logCommerce(event, outputDimensionsAndMetrics, event.CustomFlags);
-                          reportEvent = true;
-                      }
-                      else if (event.EventDataType == MessageType.PageEvent) {
-                          reportEvent = true;
-
-                          logEvent(event, outputDimensionsAndMetrics, event.CustomFlags);
-                      }
-
-                      if (reportEvent && reportingService) {
-                          reportingService(self, event);
-                      }
-
-                      return 'Successfully sent to ' + name;
-                  }
-                  catch (e) {
-                      return 'Failed to send to: ' + name + ' ' + e;
-                  }
-              }
-
-              return 'Can\'t send to forwarder ' + name + ', not initialized';
-          }
-
-          function setUserIdentity(id, type) {
-              if (isInitialized) {
-                  if (forwarderSettings.useCustomerId == 'True' && type == window.mParticle.IdentityType.CustomerId) {
-                      if (forwarderSettings.classicMode == 'True') ;
-                      else {
-                          ga(createCmd('set'), 'userId', window.mParticle.generateHash(id));
-                      }
-                  }
-              }
-              else {
-                  return 'Can\'t call setUserIdentity on forwarder ' + name + ', not initialized';
-              }
-          }
-
-          function addEcommerceProduct(product, updatedProductDimentionAndMetrics) {
-              var productAttrs = {
-                  id: product.Sku,
-                  name: product.Name,
-                  category: product.Category,
-                  brand: product.Brand,
-                  variant: product.Variant,
-                  price: product.Price,
-                  coupon: product.CouponCode,
-                  quantity: product.Quantity
-              };
-
-              for (var attr in updatedProductDimentionAndMetrics) {
-                  if (updatedProductDimentionAndMetrics.hasOwnProperty(attr)) {
-                      productAttrs[attr] = updatedProductDimentionAndMetrics[attr];
-                  }
-              }
-
-              ga(createCmd('ec:addProduct'), productAttrs);
-          }
-
-          function addEcommerceProductImpression(product) {
-              ga(createCmd('ec:addImpression'), {
-                  id: product.Sku,
-                  name: product.Name,
-                  type: 'view',
-                  category: product.Category,
-                  brand: product.Brand,
-                  variant: product.Variant
-              });
-          }
-
-          function sendEcommerceEvent(type, outputDimensionsAndMetrics, customFlags) {
-              ga(createCmd('send'), customFlags && customFlags[HITTYPE] ? customFlags[HITTYPE] : 'event', 'eCommerce', getEventTypeName(type), outputDimensionsAndMetrics);
-          }
-
-          function logCommerce(data, outputDimensionsAndMetrics, customFlags) {
-              if (!isEnhancedEcommerceLoaded) {
-                  ga(createCmd('require'), 'ec');
-                  isEnhancedEcommerceLoaded = true;
-              }
-
-              if (data.CurrencyCode) {
-                  // Set currency code if present
-                  ga(createCmd('set'), '&cu', data.CurrencyCode);
-              }
-
-              if (data.ProductImpressions) {
-                  // Impression event
-                  data.ProductImpressions.forEach(function(impression) {
-                      impression.ProductList.forEach(function(product) {
-                          addEcommerceProductImpression(product);
-                      });
-                  });
-
-                  sendEcommerceEvent(data.EventCategory, outputDimensionsAndMetrics, customFlags);
-              }
-              else if (data.PromotionAction) {
-                  // Promotion event
-                  data.PromotionAction.PromotionList.forEach(function(promotion) {
-                      ga(createCmd('ec:addPromo'), {
-                          id: promotion.Id,
-                          name: promotion.Name,
-                          creative: promotion.Creative,
-                          position: promotion.Position
-                      });
-                  });
-
-                  if (data.PromotionAction.PromotionActionType == mParticle.PromotionType.PromotionClick) {
-                      ga(createCmd('ec:setAction'), 'promo_click');
-                  }
-
-                  sendEcommerceEvent(data.EventDataType, outputDimensionsAndMetrics, customFlags);
-              }
-              else if (data.ProductAction) {
-                  if (data.ProductAction.ProductActionType == mParticle.ProductActionType.Purchase) {
-                      data.ProductAction.ProductList.forEach(function(product) {
-                          var updatedProductDimentionAndMetrics = {};
-                          applyCustomDimensionsMetricsForSourceAttributes(product.Attributes, updatedProductDimentionAndMetrics, productLevelMap);
-                          addEcommerceProduct(product, updatedProductDimentionAndMetrics);
-                      });
-
-                      ga(createCmd('ec:setAction'), 'purchase', {
-                          id: data.ProductAction.TransactionId,
-                          affiliation: data.ProductAction.Affiliation,
-                          revenue: data.ProductAction.TotalAmount,
-                          tax: data.ProductAction.TaxAmount,
-                          shipping: data.ProductAction.ShippingAmount,
-                          coupon: data.ProductAction.CouponCode
-                      });
-
-                      sendEcommerceEvent(data.EventDataType, outputDimensionsAndMetrics, customFlags);
-                  }
-                  else if (data.ProductAction.ProductActionType == mParticle.ProductActionType.Refund) {
-                      if (data.ProductAction.ProductList.length) {
-                          data.ProductAction.ProductList.forEach(function(product) {
-                              var productAttrs = {
-                                  id: product.Sku,
-                                  quantity: product.Quantity
-                              };
-                              applyCustomDimensionsMetricsForSourceAttributes(product.Attributes, productAttrs, productLevelMap);
-                              ga(createCmd('ec:addProduct'), productAttrs);
-                          });
-                      }
-
-                      ga(createCmd('ec:setAction'), 'refund', {
-                          id: data.ProductAction.TransactionId
-                      });
-
-                      sendEcommerceEvent(data.EventDataType, outputDimensionsAndMetrics, customFlags);
-                  }
-                  else if (data.ProductAction.ProductActionType == mParticle.ProductActionType.AddToCart ||
-                      data.ProductAction.ProductActionType == mParticle.ProductActionType.RemoveFromCart) {
-                      var updatedProductDimentionAndMetrics = {};
-                      data.ProductAction.ProductList.forEach(function(product) {
-                          applyCustomDimensionsMetricsForSourceAttributes(product.Attributes, updatedProductDimentionAndMetrics, productLevelMap);
-                          addEcommerceProduct(product, updatedProductDimentionAndMetrics);
-                      });
-
-                      ga(createCmd('ec:setAction'),
-                          data.ProductAction.ProductActionType == mParticle.ProductActionType.AddToCart ? 'add' : 'remove');
-
-                      sendEcommerceEvent(data.EventDataType, outputDimensionsAndMetrics, customFlags);
-                  }
-                  else if (data.ProductAction.ProductActionType == mParticle.ProductActionType.Checkout) {
-                      data.ProductAction.ProductList.forEach(function(product) {
-                          var updatedProductDimentionAndMetrics = {};
-                          applyCustomDimensionsMetricsForSourceAttributes(product.Attributes, updatedProductDimentionAndMetrics, productLevelMap);
-                          addEcommerceProduct(product, updatedProductDimentionAndMetrics);
-                      });
-
-                      ga(createCmd('ec:setAction'), 'checkout', {
-                          step: data.ProductAction.CheckoutStep,
-                          option: data.ProductAction.CheckoutOptions
-                      });
-
-                      sendEcommerceEvent(data.EventDataType, outputDimensionsAndMetrics, customFlags);
-                  }
-                  else if (data.ProductAction.ProductActionType == mParticle.ProductActionType.Click) {
-                      data.ProductAction.ProductList.forEach(function(product) {
-                          var updatedProductDimentionAndMetrics = {};
-                          applyCustomDimensionsMetricsForSourceAttributes(product.Attributes, updatedProductDimentionAndMetrics, productLevelMap);
-                          addEcommerceProduct(product, updatedProductDimentionAndMetrics);
-                      });
-
-                      ga(createCmd('ec:setAction'), 'click');
-                      sendEcommerceEvent(data.EventDataType, outputDimensionsAndMetrics, customFlags);
-                  }
-                  else if (data.ProductAction.ProductActionType == mParticle.ProductActionType.ViewDetail) {
-                      data.ProductAction.ProductList.forEach(function(product) {
-                          var updatedProductDimentionAndMetrics = {};
-                          applyCustomDimensionsMetricsForSourceAttributes(product.Attributes, updatedProductDimentionAndMetrics, productLevelMap);
-                          addEcommerceProduct(product );
-                      });
-
-                      ga(createCmd('ec:setAction'), 'detail');
-                      ga(createCmd('send'), customFlags && customFlags[HITTYPE] ? customFlags[HITTYPE] : 'event', 'eCommerce', getEventTypeName(data.EventCategory), outputDimensionsAndMetrics);
-                  }
-              }
-          }
-
-          function logPageView(event, outputDimensionsAndMetrics, customFlags) {
-              if (forwarderSettings.classicMode == 'True') {
-                  _gaq.push(['_trackPageview']);
-              }
-              else {
-                  if (event.CustomFlags && event.CustomFlags[PAGE]) {
-                      ga(createCmd('set'), 'page', event.CustomFlags[PAGE]);
-                  }
-                  ga(createCmd('send'), customFlags && customFlags[HITTYPE] ? customFlags[HITTYPE] : 'pageview', outputDimensionsAndMetrics);
-              }
-          }
-
-          function logEvent(data, outputDimensionsAndMetrics, customFlags) {
-              var label = '',
-                  category = getEventTypeName(data.EventCategory),
-                  value;
-
-              if (data.EventAttributes) {
-                  if (data.EventAttributes.label) {
-                      label = data.EventAttributes.label;
-                  }
-
-                  if (data.EventAttributes.value) {
-                      value = parseInt(data.EventAttributes.value, 10);
-
-                      // Test for NaN
-                      if (value != value) {
-                          value = null;
-                      }
-                  }
-
-                  if (data.EventAttributes.category) {
-                      category = data.EventAttributes.category;
-                  }
-              }
-
-              if(data.CustomFlags) {
-                  var googleCategory = data.CustomFlags[CATEGORY],
-                      googleLabel = data.CustomFlags[LABEL],
-                      googleValue = parseInt(data.CustomFlags[VALUE], 10);
-
-                  if (googleCategory) {
-                      category = googleCategory;
-                  }
-
-                  if (googleLabel) {
-                      label = googleLabel;
-                  }
-
-                  // Ensure not NaN
-                  if (googleValue == googleValue) {
-                      value = googleValue;
-                  }
-              }
-
-              if (forwarderSettings.classicMode == 'True') {
-                  _gaq.push(['_trackEvent',
-                      category,
-                      data.EventName,
-                      label,
-                      value]);
-              }
-              else {
-                  ga(createCmd('send'),
-                      customFlags && customFlags[HITTYPE] ? customFlags[HITTYPE] : 'event',
-                      category,
-                      data.EventName,
-                      label,
-                      value,
-                      outputDimensionsAndMetrics);
-              }
-          }
-
-          function checkForDuplicateMapping(dimensionOrMetric, eventLevelMap) {
-              var existingMapper = eventLevelMap['customDimensions'][formatDimensionOrMetric(dimensionOrMetric.value)];
-              if (existingMapper) {
-                  console.log('Warning: both ' + existingMapper + ' & ' + dimensionOrMetric.map + ' are mapped to ' + dimensionOrMetric.value + '. ' + dimensionOrMetric.map + ' is replacing ' + existingMapper + '. If this is a mistake, please revisit the Google Analytics settings at app.mparticle.com. Otherwise, please ignore this warning.');
-              }
-          }
-
-          function initForwarder(settings, service, testMode, tid) {
-              try {
-                  forwarderSettings = settings;
-                  reportingService = service;
-                  isTesting = testMode;
-
-                  if (!tid) {
-                      trackerId = createTrackerId();
-                  }
-                  else {
-                      trackerId = tid;
-                  }
-
-                  if (forwarderSettings.classicMode == 'True') {
-                      window._gaq = window._gaq || [];
-
-                      if(testMode !== true) {
-                          window._gaq.push(['_setAccount', forwarderSettings.apiKey]);
-
-                          if (forwarderSettings.useLocalhostCookie == 'True') {
-                              window._gaq.push(['_setDomainName', 'none']);
-                          }
-
-                          (function() {
-                              var ga = document.createElement('script'); ga.type = 'text/javascript'; ga.async = true;
-                              if (forwarderSettings.useDisplayFeatures == 'True') {
-                                  ga.src = ('https:' == document.location.protocol ? 'https://' : 'http://') + 'stats.g.doubleclick.net/dc.js';
-                              } else {
-                                  ga.src = ('https:' == document.location.protocol ? 'https://ssl' : 'http://www') + '.google-analytics.com/ga.js';
-                              }
-                              var s = document.getElementsByTagName('script')[0]; s.parentNode.insertBefore(ga, s);
-                          })();
-                      }
-                  }
-                  else {
-                      if(testMode !== true) {
-                          (function(i, s, o, g, r, a, m) {
-                              i['GoogleAnalyticsObject'] = r; i[r] = i[r] || function() {
-                                  (i[r].q = i[r].q || []).push(arguments);
-                              }, i[r].l = 1 * new Date(); a = s.createElement(o),
-                              m = s.getElementsByTagName(o)[0]; a.async = 1; a.src = g; m.parentNode.insertBefore(a, m);
-                          })(window, document, 'script', '//www.google-analytics.com/analytics.js', 'ga');
-                      }
-
-                      var fieldsObject = {
-                          trackingId:forwarderSettings.apiKey,
-                          name: trackerId
-                      };
-
-                      if (forwarderSettings.useLocalhostCookie == 'True') {
-                          fieldsObject.cookieDomain = 'none';
-                      }
-
-                      if (forwarderSettings.clientIdentificationType === 'AMP') {
-                          fieldsObject.useAmpClientId = true;
-                      }
-
-                      ga('create', fieldsObject);
-
-                      if (forwarderSettings.useDisplayFeatures == 'True') {
-                          ga(createCmd('require'), 'displayfeatures');
-                      }
-
-                      if (forwarderSettings.useSecure == 'True') {
-                          ga(createCmd('set'), 'forceSSL', true);
-                      }
-                      if (forwarderSettings.customDimensions) {
-                          var customDimensions = JSON.parse(forwarderSettings.customDimensions.replace(/&quot;/g, '\"'));
-                          customDimensions.forEach(function(dimension) {
-                              if (dimension.maptype === 'EventAttributeClass.Name') {
-                                  checkForDuplicateMapping(dimension, eventLevelMap);
-                                  eventLevelMap['customDimensions'][formatDimensionOrMetric(dimension.value)] = dimension.map;
-                              } else if (dimension.maptype === 'UserAttributeClass.Name') {
-                                  checkForDuplicateMapping(dimension, userLevelMap);
-                                  userLevelMap['customDimensions'][formatDimensionOrMetric(dimension.value)] = dimension.map;
-                              } else if (dimension.maptype === 'ProductAttributeSelector.Name') {
-                                  checkForDuplicateMapping(dimension, productLevelMap);
-                                  productLevelMap['customDimensions'][formatDimensionOrMetric(dimension.value)] = dimension.map;
-                              }
-                          });
-                      }
-
-                      if (forwarderSettings.customMetrics) {
-                          var customMetrics = JSON.parse(forwarderSettings.customMetrics.replace(/&quot;/g, '\"'));
-                          customMetrics.forEach(function(metric) {
-                              if (metric.maptype === 'EventAttributeClass.Name') {
-                                  checkForDuplicateMapping(metric, eventLevelMap);
-                                  eventLevelMap['customMetrics'][formatDimensionOrMetric(metric.value)] = metric.map;
-                              } else if (metric.maptype === 'UserAttributeClass.Name') {
-                                  checkForDuplicateMapping(metric, userLevelMap);
-                                  userLevelMap['customMetrics'][formatDimensionOrMetric(metric.value)] = metric.map;
-                              } else if (metric.maptype === 'ProductAttributeSelector.Name') {
-                                  checkForDuplicateMapping(metric, productLevelMap);
-                                  productLevelMap['customMetrics'][formatDimensionOrMetric(metric.value)] = metric.map;
-                              }
-                          });
-                      }
-                  }
-
-                  isInitialized = true;
-                  return 'Successfully initialized: ' + name;
-              }
-              catch (e) {
-                  return 'Failed to initialize: ' + name;
-              }
-          }
-
-          this.init = initForwarder;
-          this.process = processEvent;
-          this.setUserIdentity = setUserIdentity;
-      };
-
-      function getId() {
-          return moduleId;
-      }
-
-      function register(config) {
-          if (!config) {
-              window.console.log('You must pass a config object to register the kit ' + name);
-              return;
-          }
-
-          if (!isObject(config)) {
-              window.console.log('\'config\' must be an object. You passed in a ' + typeof config);
-              return;
-          }
-
-          if (isObject(config.kits)) {
-              config.kits[name] = {
-                  constructor: constructor
-              };
-          } else {
-              config.kits = {};
-              config.kits[name] = {
-                  constructor: constructor
-              };
-          }
-          window.console.log('Successfully registered ' + name + ' to your mParticle configuration');
-      }
-
-      if (window && window.mParticle && window.mParticle.addForwarder) {
-          window.mParticle.addForwarder({
-              name: name,
-              constructor: constructor,
-              getId: getId
-          });
-      }
-
-      var GoogleAnalyticsEventForwarder = {
-          register: register
-      };
-  var GoogleAnalyticsEventForwarder_1 = GoogleAnalyticsEventForwarder.register;
-
-  exports.default = GoogleAnalyticsEventForwarder;
-  exports.register = GoogleAnalyticsEventForwarder_1;
-
-  return exports;
+    /* eslint-disable no-undef*/
+    //
+    //  Copyright 2019 mParticle, Inc.
+    //
+    //  Licensed under the Apache License, Version 2.0 (the "License");
+    //  you may not use this file except in compliance with the License.
+    //  You may obtain a copy of the License at
+    //
+    //      http://www.apache.org/licenses/LICENSE-2.0
+    //
+    //  Unless required by applicable law or agreed to in writing, software
+    //  distributed under the License is distributed on an "AS IS" BASIS,
+    //  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    //  See the License for the specific language governing permissions and
+    //  limitations under the License.
+
+        var name = 'GoogleAnalyticsEventForwarder',
+            moduleId = 6,
+            MessageType = {
+                SessionStart: 1,
+                SessionEnd: 2,
+                PageView: 3,
+                PageEvent: 4,
+                CrashReport: 5,
+                OptOut: 6,
+                Commerce: 16
+            },
+            trackerCount = 1,
+            NON_INTERACTION_FLAG = 'Google.NonInteraction',
+            CATEGORY = 'Google.Category',
+            LABEL = 'Google.Label',
+            PAGE = 'Google.Page',
+            VALUE = 'Google.Value',
+            HITTYPE = 'Google.HitType';
+
+        var constructor = function() {
+            var self = this,
+                isInitialized = false,
+                isEnhancedEcommerceLoaded = false,
+                forwarderSettings,
+                reportingService,
+                trackerId = null,
+                eventLevelMap = {
+                    customDimensions: {},
+                    customMetrics: {}
+                },
+                userLevelMap = {
+                    customDimensions: {},
+                    customMetrics: {}
+                },
+                productLevelMap = {
+                    customDimensions: {},
+                    customMetrics: {}
+                };
+
+            self.name = name;
+
+            function createTrackerId() {
+                return 'mpgaTracker' + trackerCount++;
+            }
+
+            function createCmd(cmd) {
+                // Prepends the specified command with the tracker id
+                return trackerId + '.' + cmd;
+            }
+
+            function getEventTypeName(eventType) {
+                return mParticle.EventType.getName(eventType);
+            }
+
+            function formatDimensionOrMetric(attr) {
+                return attr.replace(/ /g, '').toLowerCase();
+            }
+
+            function applyCustomDimensionsAndMetrics(event, outputDimensionsAndMetrics) {
+                // apply custom dimensions and metrics to each event, product, or user if respective attributes exist
+                if (event.EventAttributes && Object.keys(event.EventAttributes).length) {
+                    applyCustomDimensionsMetricsForSourceAttributes(event.EventAttributes, outputDimensionsAndMetrics, eventLevelMap);
+                }
+
+                if (event.UserAttributes && Object.keys(event.UserAttributes).length) {
+                    applyCustomDimensionsMetricsForSourceAttributes(event.UserAttributes, outputDimensionsAndMetrics, userLevelMap);
+                }
+            }
+
+            function applyCustomDimensionsMetricsForSourceAttributes(attributes, targetDimensionsAndMetrics, mapLevel) {
+                for (var customDimension in mapLevel.customDimensions) {
+                    for (attrName in attributes) {
+                        if (customDimension === attrName) {
+                            targetDimensionsAndMetrics[mapLevel.customDimensions[customDimension]] = attributes[attrName];
+                        }
+                    }
+                }
+
+                for (var customMetric in mapLevel.customMetrics) {
+                    for (attrName in attributes) {
+                        if (customMetric === attrName) {
+                            targetDimensionsAndMetrics[mapLevel.customMetrics[customMetric]] = attributes[attrName];
+                        }
+                    }
+                }
+            }
+
+            function applyCustomFlags(flags, outputDimensionsAndMetrics) {
+                if (flags.hasOwnProperty(NON_INTERACTION_FLAG)) {
+                    outputDimensionsAndMetrics['nonInteraction'] = flags[NON_INTERACTION_FLAG];
+                }
+            }
+
+            function processEvent(event) {
+                var outputDimensionsAndMetrics = {};
+                var reportEvent = false;
+
+                if (isInitialized) {
+                    event.ExpandedEventCount = 0;
+
+                    applyCustomDimensionsAndMetrics(event, outputDimensionsAndMetrics);
+
+                    if (event.CustomFlags && Object.keys(event.CustomFlags).length) {
+                        applyCustomFlags(event.CustomFlags, outputDimensionsAndMetrics);
+                    }
+
+                    try {
+                        if (event.EventDataType == MessageType.PageView) {
+                            logPageView(event, outputDimensionsAndMetrics, event.CustomFlags);
+                            reportEvent = true;
+                        }
+                        else if (event.EventDataType == MessageType.Commerce) {
+                            logCommerce(event, outputDimensionsAndMetrics, event.CustomFlags);
+                            reportEvent = true;
+                        }
+                        else if (event.EventDataType == MessageType.PageEvent) {
+                            reportEvent = true;
+
+                            logEvent(event, outputDimensionsAndMetrics, event.CustomFlags);
+                        }
+
+                        if (reportEvent && reportingService) {
+                            reportingService(self, event);
+                        }
+
+                        return 'Successfully sent to ' + name;
+                    }
+                    catch (e) {
+                        return 'Failed to send to: ' + name + ' ' + e;
+                    }
+                }
+
+                return 'Can\'t send to forwarder ' + name + ', not initialized';
+            }
+
+            function setUserIdentity(id, type) {
+                if (isInitialized) {
+                    if (forwarderSettings.useCustomerId == 'True' && type == window.mParticle.IdentityType.CustomerId) {
+                        if (forwarderSettings.classicMode == 'True') ;
+                        else {
+                            ga(createCmd('set'), 'userId', window.mParticle.generateHash(id));
+                        }
+                    }
+                }
+                else {
+                    return 'Can\'t call setUserIdentity on forwarder ' + name + ', not initialized';
+                }
+            }
+
+            function addEcommerceProduct(product, updatedProductDimentionAndMetrics) {
+                var productAttrs = {
+                    id: product.Sku,
+                    name: product.Name,
+                    category: product.Category,
+                    brand: product.Brand,
+                    variant: product.Variant,
+                    price: product.Price,
+                    coupon: product.CouponCode,
+                    quantity: product.Quantity
+                };
+
+                for (var attr in updatedProductDimentionAndMetrics) {
+                    if (updatedProductDimentionAndMetrics.hasOwnProperty(attr)) {
+                        productAttrs[attr] = updatedProductDimentionAndMetrics[attr];
+                    }
+                }
+
+                ga(createCmd('ec:addProduct'), productAttrs);
+            }
+
+            function addEcommerceProductImpression(product) {
+                ga(createCmd('ec:addImpression'), {
+                    id: product.Sku,
+                    name: product.Name,
+                    type: 'view',
+                    category: product.Category,
+                    brand: product.Brand,
+                    variant: product.Variant
+                });
+            }
+
+            function sendEcommerceEvent(type, outputDimensionsAndMetrics, customFlags) {
+                ga(createCmd('send'), customFlags && customFlags[HITTYPE] ? customFlags[HITTYPE] : 'event', 'eCommerce', getEventTypeName(type), outputDimensionsAndMetrics);
+            }
+
+            function logCommerce(data, outputDimensionsAndMetrics, customFlags) {
+                if (!isEnhancedEcommerceLoaded) {
+                    ga(createCmd('require'), 'ec');
+                    isEnhancedEcommerceLoaded = true;
+                }
+
+                if (data.CurrencyCode) {
+                    // Set currency code if present
+                    ga(createCmd('set'), '&cu', data.CurrencyCode);
+                }
+
+                if (data.ProductImpressions) {
+                    // Impression event
+                    data.ProductImpressions.forEach(function(impression) {
+                        impression.ProductList.forEach(function(product) {
+                            addEcommerceProductImpression(product);
+                        });
+                    });
+
+                    sendEcommerceEvent(data.EventCategory, outputDimensionsAndMetrics, customFlags);
+                }
+                else if (data.PromotionAction) {
+                    // Promotion event
+                    data.PromotionAction.PromotionList.forEach(function(promotion) {
+                        ga(createCmd('ec:addPromo'), {
+                            id: promotion.Id,
+                            name: promotion.Name,
+                            creative: promotion.Creative,
+                            position: promotion.Position
+                        });
+                    });
+
+                    if (data.PromotionAction.PromotionActionType == mParticle.PromotionType.PromotionClick) {
+                        ga(createCmd('ec:setAction'), 'promo_click');
+                    }
+
+                    sendEcommerceEvent(data.EventDataType, outputDimensionsAndMetrics, customFlags);
+                }
+                else if (data.ProductAction) {
+                    if (data.ProductAction.ProductActionType == mParticle.ProductActionType.Purchase) {
+                        data.ProductAction.ProductList.forEach(function(product) {
+                            var updatedProductDimentionAndMetrics = {};
+                            applyCustomDimensionsMetricsForSourceAttributes(product.Attributes, updatedProductDimentionAndMetrics, productLevelMap);
+                            addEcommerceProduct(product, updatedProductDimentionAndMetrics);
+                        });
+
+                        ga(createCmd('ec:setAction'), 'purchase', {
+                            id: data.ProductAction.TransactionId,
+                            affiliation: data.ProductAction.Affiliation,
+                            revenue: data.ProductAction.TotalAmount,
+                            tax: data.ProductAction.TaxAmount,
+                            shipping: data.ProductAction.ShippingAmount,
+                            coupon: data.ProductAction.CouponCode
+                        });
+
+                        sendEcommerceEvent(data.EventDataType, outputDimensionsAndMetrics, customFlags);
+                    }
+                    else if (data.ProductAction.ProductActionType == mParticle.ProductActionType.Refund) {
+                        if (data.ProductAction.ProductList.length) {
+                            data.ProductAction.ProductList.forEach(function(product) {
+                                var productAttrs = {
+                                    id: product.Sku,
+                                    quantity: product.Quantity
+                                };
+                                applyCustomDimensionsMetricsForSourceAttributes(product.Attributes, productAttrs, productLevelMap);
+                                ga(createCmd('ec:addProduct'), productAttrs);
+                            });
+                        }
+
+                        ga(createCmd('ec:setAction'), 'refund', {
+                            id: data.ProductAction.TransactionId
+                        });
+
+                        sendEcommerceEvent(data.EventDataType, outputDimensionsAndMetrics, customFlags);
+                    }
+                    else if (data.ProductAction.ProductActionType == mParticle.ProductActionType.AddToCart ||
+                        data.ProductAction.ProductActionType == mParticle.ProductActionType.RemoveFromCart) {
+                        var updatedProductDimentionAndMetrics = {};
+                        data.ProductAction.ProductList.forEach(function(product) {
+                            applyCustomDimensionsMetricsForSourceAttributes(product.Attributes, updatedProductDimentionAndMetrics, productLevelMap);
+                            addEcommerceProduct(product, updatedProductDimentionAndMetrics);
+                        });
+
+                        ga(createCmd('ec:setAction'),
+                            data.ProductAction.ProductActionType == mParticle.ProductActionType.AddToCart ? 'add' : 'remove');
+
+                        sendEcommerceEvent(data.EventDataType, outputDimensionsAndMetrics, customFlags);
+                    }
+                    else if (data.ProductAction.ProductActionType == mParticle.ProductActionType.Checkout) {
+                        data.ProductAction.ProductList.forEach(function(product) {
+                            var updatedProductDimentionAndMetrics = {};
+                            applyCustomDimensionsMetricsForSourceAttributes(product.Attributes, updatedProductDimentionAndMetrics, productLevelMap);
+                            addEcommerceProduct(product, updatedProductDimentionAndMetrics);
+                        });
+
+                        ga(createCmd('ec:setAction'), 'checkout', {
+                            step: data.ProductAction.CheckoutStep,
+                            option: data.ProductAction.CheckoutOptions
+                        });
+
+                        sendEcommerceEvent(data.EventDataType, outputDimensionsAndMetrics, customFlags);
+                    }
+                    else if (data.ProductAction.ProductActionType == mParticle.ProductActionType.Click) {
+                        data.ProductAction.ProductList.forEach(function(product) {
+                            var updatedProductDimentionAndMetrics = {};
+                            applyCustomDimensionsMetricsForSourceAttributes(product.Attributes, updatedProductDimentionAndMetrics, productLevelMap);
+                            addEcommerceProduct(product, updatedProductDimentionAndMetrics);
+                        });
+
+                        ga(createCmd('ec:setAction'), 'click');
+                        sendEcommerceEvent(data.EventDataType, outputDimensionsAndMetrics, customFlags);
+                    }
+                    else if (data.ProductAction.ProductActionType == mParticle.ProductActionType.ViewDetail) {
+                        data.ProductAction.ProductList.forEach(function(product) {
+                            var updatedProductDimentionAndMetrics = {};
+                            applyCustomDimensionsMetricsForSourceAttributes(product.Attributes, updatedProductDimentionAndMetrics, productLevelMap);
+                            addEcommerceProduct(product );
+                        });
+
+                        ga(createCmd('ec:setAction'), 'detail');
+                        ga(createCmd('send'), customFlags && customFlags[HITTYPE] ? customFlags[HITTYPE] : 'event', 'eCommerce', getEventTypeName(data.EventCategory), outputDimensionsAndMetrics);
+                    }
+                }
+            }
+
+            function logPageView(event, outputDimensionsAndMetrics, customFlags) {
+                if (forwarderSettings.classicMode == 'True') {
+                    _gaq.push(['_trackPageview']);
+                }
+                else {
+                    if (event.CustomFlags && event.CustomFlags[PAGE]) {
+                        ga(createCmd('set'), 'page', event.CustomFlags[PAGE]);
+                    }
+                    ga(createCmd('send'), customFlags && customFlags[HITTYPE] ? customFlags[HITTYPE] : 'pageview', outputDimensionsAndMetrics);
+                }
+            }
+
+            function logEvent(data, outputDimensionsAndMetrics, customFlags) {
+                var label = '',
+                    category = getEventTypeName(data.EventCategory),
+                    value;
+
+                if (data.EventAttributes) {
+                    if (data.EventAttributes.label) {
+                        label = data.EventAttributes.label;
+                    }
+
+                    if (data.EventAttributes.value) {
+                        value = parseInt(data.EventAttributes.value, 10);
+
+                        // Test for NaN
+                        if (value != value) {
+                            value = null;
+                        }
+                    }
+
+                    if (data.EventAttributes.category) {
+                        category = data.EventAttributes.category;
+                    }
+                }
+
+                if(data.CustomFlags) {
+                    var googleCategory = data.CustomFlags[CATEGORY],
+                        googleLabel = data.CustomFlags[LABEL],
+                        googleValue = parseInt(data.CustomFlags[VALUE], 10);
+
+                    if (googleCategory) {
+                        category = googleCategory;
+                    }
+
+                    if (googleLabel) {
+                        label = googleLabel;
+                    }
+
+                    // Ensure not NaN
+                    if (googleValue == googleValue) {
+                        value = googleValue;
+                    }
+                }
+
+                if (forwarderSettings.classicMode == 'True') {
+                    _gaq.push(['_trackEvent',
+                        category,
+                        data.EventName,
+                        label,
+                        value]);
+                }
+                else {
+                    ga(createCmd('send'),
+                        customFlags && customFlags[HITTYPE] ? customFlags[HITTYPE] : 'event',
+                        category,
+                        data.EventName,
+                        label,
+                        value,
+                        outputDimensionsAndMetrics);
+                }
+            }
+
+            function initForwarder(settings, service, testMode, tid) {
+                try {
+                    forwarderSettings = settings;
+                    reportingService = service;
+                    isTesting = testMode;
+
+                    if (!tid) {
+                        trackerId = createTrackerId();
+                    }
+                    else {
+                        trackerId = tid;
+                    }
+
+                    if (forwarderSettings.classicMode == 'True') {
+                        window._gaq = window._gaq || [];
+
+                        if(testMode !== true) {
+                            window._gaq.push(['_setAccount', forwarderSettings.apiKey]);
+
+                            if (forwarderSettings.useLocalhostCookie == 'True') {
+                                window._gaq.push(['_setDomainName', 'none']);
+                            }
+
+                            (function() {
+                                var ga = document.createElement('script'); ga.type = 'text/javascript'; ga.async = true;
+                                if (forwarderSettings.useDisplayFeatures == 'True') {
+                                    ga.src = ('https:' == document.location.protocol ? 'https://' : 'http://') + 'stats.g.doubleclick.net/dc.js';
+                                } else {
+                                    ga.src = ('https:' == document.location.protocol ? 'https://ssl' : 'http://www') + '.google-analytics.com/ga.js';
+                                }
+                                var s = document.getElementsByTagName('script')[0]; s.parentNode.insertBefore(ga, s);
+                            })();
+                        }
+                    }
+                    else {
+                        if(testMode !== true) {
+                            (function(i, s, o, g, r, a, m) {
+                                i['GoogleAnalyticsObject'] = r; i[r] = i[r] || function() {
+                                    (i[r].q = i[r].q || []).push(arguments);
+                                }, i[r].l = 1 * new Date(); a = s.createElement(o),
+                                m = s.getElementsByTagName(o)[0]; a.async = 1; a.src = g; m.parentNode.insertBefore(a, m);
+                            })(window, document, 'script', '//www.google-analytics.com/analytics.js', 'ga');
+                        }
+
+                        var fieldsObject = {
+                            trackingId:forwarderSettings.apiKey,
+                            name: trackerId
+                        };
+
+                        if (forwarderSettings.useLocalhostCookie == 'True') {
+                            fieldsObject.cookieDomain = 'none';
+                        }
+
+                        if (forwarderSettings.clientIdentificationType === 'AMP') {
+                            fieldsObject.useAmpClientId = true;
+                        }
+
+                        ga('create', fieldsObject);
+
+                        if (forwarderSettings.useDisplayFeatures == 'True') {
+                            ga(createCmd('require'), 'displayfeatures');
+                        }
+
+                        if (forwarderSettings.useSecure == 'True') {
+                            ga(createCmd('set'), 'forceSSL', true);
+                        }
+                        if (forwarderSettings.customDimensions) {
+                            var customDimensions = JSON.parse(forwarderSettings.customDimensions.replace(/&quot;/g, '\"'));
+                            customDimensions.forEach(function(dimension) {
+                                if (dimension.maptype === 'EventAttributeClass.Name') {
+                                    eventLevelMap['customDimensions'][dimension.map] = formatDimensionOrMetric(dimension.value);
+                                } else if (dimension.maptype === 'UserAttributeClass.Name') {
+                                    userLevelMap['customDimensions'][dimension.map] = formatDimensionOrMetric(dimension.value);
+                                } else if (dimension.maptype === 'ProductAttributeSelector.Name') {
+                                    productLevelMap['customDimensions'][dimension.map] = formatDimensionOrMetric(dimension.value);
+                                }
+                            });
+                        }
+
+                        if (forwarderSettings.customMetrics) {
+                            var customMetrics = JSON.parse(forwarderSettings.customMetrics.replace(/&quot;/g, '\"'));
+                            customMetrics.forEach(function(metric) {
+                                if (metric.maptype === 'EventAttributeClass.Name') {
+                                    eventLevelMap['customMetrics'][metric.map] = formatDimensionOrMetric(metric.value);
+                                } else if (metric.maptype === 'UserAttributeClass.Name') {
+                                    userLevelMap['customMetrics'][metric.map] = formatDimensionOrMetric(metric.value);
+                                } else if (metric.maptype === 'ProductAttributeSelector.Name') {
+                                    productLevelMap['customMetrics'][metric.map] = formatDimensionOrMetric(metric.value);
+                                }
+                            });
+                        }
+                    }
+
+                    isInitialized = true;
+                    return 'Successfully initialized: ' + name;
+                }
+                catch (e) {
+                    return 'Failed to initialize: ' + name;
+                }
+            }
+
+            this.init = initForwarder;
+            this.process = processEvent;
+            this.setUserIdentity = setUserIdentity;
+        };
+
+        function getId() {
+            return moduleId;
+        }
+
+        function isObject(val) {
+            return val != null && typeof val === 'object' && Array.isArray(val) === false;
+        }
+
+        function register(config) {
+            if (!config) {
+                window.console.log('You must pass a config object to register the kit ' + name);
+                return;
+            }
+
+            if (!isObject(config)) {
+                window.console.log('\'config\' must be an object. You passed in a ' + typeof config);
+                return;
+            }
+
+            if (isObject(config.kits)) {
+                config.kits[name] = {
+                    constructor: constructor
+                };
+            } else {
+                config.kits = {};
+                config.kits[name] = {
+                    constructor: constructor
+                };
+            }
+            window.console.log('Successfully registered ' + name + ' to your mParticle configuration');
+        }
+
+        if (window && window.mParticle && window.mParticle.addForwarder) {
+            window.mParticle.addForwarder({
+                name: name,
+                constructor: constructor,
+                getId: getId
+            });
+        }
+
+        var GoogleAnalyticsEventForwarder = {
+            register: register
+        };
+    var GoogleAnalyticsEventForwarder_1 = GoogleAnalyticsEventForwarder.register;
+
+    exports.default = GoogleAnalyticsEventForwarder;
+    exports.register = GoogleAnalyticsEventForwarder_1;
+
+    return exports;
 
 }({}));

--- a/package-lock.json
+++ b/package-lock.json
@@ -4,6 +4,26 @@
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
+    "@babel/code-frame": {
+      "version": "7.5.5",
+      "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.5.5.tgz",
+      "integrity": "sha512-27d4lZoomVyo51VegxI20xZPuSHusqbQag/ztrBC7wegWoQ1nLREPVSKSW8byhTlzTKyNE4ifaTA6lCp7JjpFw==",
+      "dev": true,
+      "requires": {
+        "@babel/highlight": "^7.0.0"
+      }
+    },
+    "@babel/highlight": {
+      "version": "7.5.0",
+      "resolved": "https://registry.npmjs.org/@babel/highlight/-/highlight-7.5.0.tgz",
+      "integrity": "sha512-7dV4eu9gBxoM0dAnj/BCFDW9LFU0zvTrkq0ugM7pnHEgguOEeOz1so2ZghEdzviYzQEED0r4EAgpsBChKy1TRQ==",
+      "dev": true,
+      "requires": {
+        "chalk": "^2.0.0",
+        "esutils": "^2.0.2",
+        "js-tokens": "^4.0.0"
+      }
+    },
     "@mparticle/web-sdk": {
       "version": "2.9.4-rc.3",
       "resolved": "https://registry.npmjs.org/@mparticle/web-sdk/-/web-sdk-2.9.4-rc.3.tgz",
@@ -36,10 +56,150 @@
       "integrity": "sha512-jPTiwtOxaHNaAPg/dmrJ/beuzLRnXtB0kQPQ8JpotKJgTB6rX6c8mlf315941pyjBSaPg8NHXS9fhP4u17DpGA==",
       "dev": true
     },
+    "acorn-jsx": {
+      "version": "5.1.0",
+      "resolved": "https://registry.npmjs.org/acorn-jsx/-/acorn-jsx-5.1.0.tgz",
+      "integrity": "sha512-tMUqwBWfLFbJbizRmEcWSLw6HnFzfdJs2sOJEOwwtVPMoH/0Ay+E703oZz78VSXZiiDcZrQ5XKjPIUQixhmgVw==",
+      "dev": true
+    },
+    "ajv": {
+      "version": "6.10.2",
+      "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.10.2.tgz",
+      "integrity": "sha512-TXtUUEYHuaTEbLZWIKUr5pmBuhDLy+8KYtPYdcV8qC+pOZL+NKqYwvWSRrVXHn+ZmRRAu8vJTAznH7Oag6RVRw==",
+      "dev": true,
+      "requires": {
+        "fast-deep-equal": "^2.0.1",
+        "fast-json-stable-stringify": "^2.0.0",
+        "json-schema-traverse": "^0.4.1",
+        "uri-js": "^4.2.2"
+      }
+    },
+    "ansi-escapes": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/ansi-escapes/-/ansi-escapes-3.2.0.tgz",
+      "integrity": "sha512-cBhpre4ma+U0T1oM5fXg7Dy1Jw7zzwv7lt/GoCpr+hDQJoYnKVPLL4dCvSEFMmQurOQvSrwT7SL/DAlhBI97RQ==",
+      "dev": true
+    },
+    "ansi-regex": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-3.0.0.tgz",
+      "integrity": "sha1-7QMXwyIGT3lGbAKWa922Bas32Zg=",
+      "dev": true
+    },
+    "ansi-styles": {
+      "version": "3.2.1",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.1.tgz",
+      "integrity": "sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==",
+      "dev": true,
+      "requires": {
+        "color-convert": "^1.9.0"
+      }
+    },
+    "argparse": {
+      "version": "1.0.10",
+      "resolved": "https://registry.npmjs.org/argparse/-/argparse-1.0.10.tgz",
+      "integrity": "sha512-o5Roy6tNG4SL/FOkCAN6RzjiakZS25RLYFrcMttJqbdd8BWrnA+fGz57iN5Pb06pvBGvl5gQ0B48dJlslXvoTg==",
+      "dev": true,
+      "requires": {
+        "sprintf-js": "~1.0.2"
+      }
+    },
+    "astral-regex": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/astral-regex/-/astral-regex-1.0.0.tgz",
+      "integrity": "sha512-+Ryf6g3BKoRc7jfp7ad8tM4TtMiaWvbF/1/sQcZPkkS7ag3D5nMBCe2UfOTONtAkaG0tO0ij3C5Lwmf1EiyjHg==",
+      "dev": true
+    },
+    "balanced-match": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.0.tgz",
+      "integrity": "sha1-ibTRmasr7kneFk6gK4nORi1xt2c=",
+      "dev": true
+    },
+    "brace-expansion": {
+      "version": "1.1.11",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.11.tgz",
+      "integrity": "sha512-iCuPHDFgrHX7H2vEI/5xpz07zSHB00TpugqhmYtVmMO6518mCuRMoOYFldEBl0g187ufozdaHgWKcYFb61qGiA==",
+      "dev": true,
+      "requires": {
+        "balanced-match": "^1.0.0",
+        "concat-map": "0.0.1"
+      }
+    },
     "builtin-modules": {
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/builtin-modules/-/builtin-modules-3.1.0.tgz",
       "integrity": "sha512-k0KL0aWZuBt2lrxrcASWDfwOLMnodeQjodT/1SxEQAXsHANgo6ZC/VEaSEHCXt7aSTZ4/4H5LKa+tBXmW7Vtvw==",
+      "dev": true
+    },
+    "callsites": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/callsites/-/callsites-3.1.0.tgz",
+      "integrity": "sha512-P8BjAsXvZS+VIDUI11hHCQEv74YT67YUi5JJFNWIqL235sBmjX4+qx9Muvls5ivyNENctx46xQLQ3aTuE7ssaQ==",
+      "dev": true
+    },
+    "chalk": {
+      "version": "2.4.2",
+      "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.2.tgz",
+      "integrity": "sha512-Mti+f9lpJNcwF4tWV8/OrTTtF1gZi+f8FqlyAdouralcFWFQWF2+NgCHShjkCb+IFBLq9buZwE1xckQU4peSuQ==",
+      "dev": true,
+      "requires": {
+        "ansi-styles": "^3.2.1",
+        "escape-string-regexp": "^1.0.5",
+        "supports-color": "^5.3.0"
+      },
+      "dependencies": {
+        "escape-string-regexp": {
+          "version": "1.0.5",
+          "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",
+          "integrity": "sha1-G2HAViGQqN/2rjuyzwIAyhMLhtQ=",
+          "dev": true
+        },
+        "supports-color": {
+          "version": "5.5.0",
+          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.5.0.tgz",
+          "integrity": "sha512-QjVjwdXIt408MIiAqCX4oUKsgU2EqAGzs2Ppkm4aQYbjm+ZEWEcW4SfFNTr4uMNZma0ey4f5lgLrkB0aX0QMow==",
+          "dev": true,
+          "requires": {
+            "has-flag": "^3.0.0"
+          }
+        }
+      }
+    },
+    "chardet": {
+      "version": "0.7.0",
+      "resolved": "https://registry.npmjs.org/chardet/-/chardet-0.7.0.tgz",
+      "integrity": "sha512-mT8iDcrh03qDGRRmoA2hmBJnxpllMR+0/0qlzjqZES6NdiWDcZkCNAk4rPFZ9Q85r27unkiNNg8ZOiwZXBHwcA==",
+      "dev": true
+    },
+    "cli-cursor": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/cli-cursor/-/cli-cursor-2.1.0.tgz",
+      "integrity": "sha1-s12sN2R5+sw+lHR9QdDQ9SOP/LU=",
+      "dev": true,
+      "requires": {
+        "restore-cursor": "^2.0.0"
+      }
+    },
+    "cli-width": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/cli-width/-/cli-width-2.2.0.tgz",
+      "integrity": "sha1-/xnt6Kml5XkyQUewwR8PvLq+1jk=",
+      "dev": true
+    },
+    "color-convert": {
+      "version": "1.9.3",
+      "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-1.9.3.tgz",
+      "integrity": "sha512-QfAUtd+vFdAtFQcC8CCyYt1fYWxSqAiK2cSD6zDB8N3cpsEBAvRxp9zOGg6G/SHHJYAT88/az/IuDGALsNVbGg==",
+      "dev": true,
+      "requires": {
+        "color-name": "1.1.3"
+      }
+    },
+    "color-name": {
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.3.tgz",
+      "integrity": "sha1-p9BVi9icQveV3UIyj3QIMcpTvCU=",
       "dev": true
     },
     "commander": {
@@ -47,6 +207,33 @@
       "resolved": "https://registry.npmjs.org/commander/-/commander-2.3.0.tgz",
       "integrity": "sha1-/UMOiJgy7DU7ms0d4hfBHLPu+HM=",
       "dev": true
+    },
+    "concat-map": {
+      "version": "0.0.1",
+      "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
+      "integrity": "sha1-2Klr13/Wjfd5OnMDajug1UBdR3s=",
+      "dev": true
+    },
+    "cross-spawn": {
+      "version": "6.0.5",
+      "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-6.0.5.tgz",
+      "integrity": "sha512-eTVLrBSt7fjbDygz805pMnstIs2VTBNkRm0qxZd+M7A5XDdxVRWO5MxGBXZhjY4cqLYLdtrGqRf8mBPmzwSpWQ==",
+      "dev": true,
+      "requires": {
+        "nice-try": "^1.0.4",
+        "path-key": "^2.0.1",
+        "semver": "^5.5.0",
+        "shebang-command": "^1.2.0",
+        "which": "^1.2.9"
+      },
+      "dependencies": {
+        "semver": {
+          "version": "5.7.1",
+          "resolved": "https://registry.npmjs.org/semver/-/semver-5.7.1.tgz",
+          "integrity": "sha512-sauaDf/PZdVgrLTNYHRtpXa1iRiKcaebiKQ1BJdpQlWH2lCvexQdX55snPFyK7QzpudqbCI0qXFfOasHdyNDGQ==",
+          "dev": true
+        }
+      }
     },
     "debug": {
       "version": "2.2.0",
@@ -57,10 +244,31 @@
         "ms": "0.7.1"
       }
     },
+    "deep-is": {
+      "version": "0.1.3",
+      "resolved": "https://registry.npmjs.org/deep-is/-/deep-is-0.1.3.tgz",
+      "integrity": "sha1-s2nW+128E+7PUk+RsHD+7cNXzzQ=",
+      "dev": true
+    },
     "diff": {
       "version": "1.4.0",
       "resolved": "https://registry.npmjs.org/diff/-/diff-1.4.0.tgz",
       "integrity": "sha1-fyjS657nsVqX79ic5j3P2qPMur8=",
+      "dev": true
+    },
+    "doctrine": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/doctrine/-/doctrine-3.0.0.tgz",
+      "integrity": "sha512-yS+Q5i3hBf7GBkd4KG8a7eBNNWNGLTaEwwYWUijIYM7zrlYDM0BFXHjjPWlWZ1Rg7UaddZeIDmi9jF3HmqiQ2w==",
+      "dev": true,
+      "requires": {
+        "esutils": "^2.0.2"
+      }
+    },
+    "emoji-regex": {
+      "version": "7.0.3",
+      "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-7.0.3.tgz",
+      "integrity": "sha512-CwBLREIQ7LvYFB0WyRvwhq5N5qPhc6PMjD6bYggFlI5YyDgl+0vxq5VHbMOFqLg7hfWzmu8T5Z1QofhmTIhItA==",
       "dev": true
     },
     "escape-string-regexp": {
@@ -69,10 +277,275 @@
       "integrity": "sha1-Tbwv5nTnGUnK8/smlc5/LcHZqNE=",
       "dev": true
     },
+    "eslint": {
+      "version": "6.5.1",
+      "resolved": "https://registry.npmjs.org/eslint/-/eslint-6.5.1.tgz",
+      "integrity": "sha512-32h99BoLYStT1iq1v2P9uwpyznQ4M2jRiFB6acitKz52Gqn+vPaMDUTB1bYi1WN4Nquj2w+t+bimYUG83DC55A==",
+      "dev": true,
+      "requires": {
+        "@babel/code-frame": "^7.0.0",
+        "ajv": "^6.10.0",
+        "chalk": "^2.1.0",
+        "cross-spawn": "^6.0.5",
+        "debug": "^4.0.1",
+        "doctrine": "^3.0.0",
+        "eslint-scope": "^5.0.0",
+        "eslint-utils": "^1.4.2",
+        "eslint-visitor-keys": "^1.1.0",
+        "espree": "^6.1.1",
+        "esquery": "^1.0.1",
+        "esutils": "^2.0.2",
+        "file-entry-cache": "^5.0.1",
+        "functional-red-black-tree": "^1.0.1",
+        "glob-parent": "^5.0.0",
+        "globals": "^11.7.0",
+        "ignore": "^4.0.6",
+        "import-fresh": "^3.0.0",
+        "imurmurhash": "^0.1.4",
+        "inquirer": "^6.4.1",
+        "is-glob": "^4.0.0",
+        "js-yaml": "^3.13.1",
+        "json-stable-stringify-without-jsonify": "^1.0.1",
+        "levn": "^0.3.0",
+        "lodash": "^4.17.14",
+        "minimatch": "^3.0.4",
+        "mkdirp": "^0.5.1",
+        "natural-compare": "^1.4.0",
+        "optionator": "^0.8.2",
+        "progress": "^2.0.0",
+        "regexpp": "^2.0.1",
+        "semver": "^6.1.2",
+        "strip-ansi": "^5.2.0",
+        "strip-json-comments": "^3.0.1",
+        "table": "^5.2.3",
+        "text-table": "^0.2.0",
+        "v8-compile-cache": "^2.0.3"
+      },
+      "dependencies": {
+        "debug": {
+          "version": "4.1.1",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-4.1.1.tgz",
+          "integrity": "sha512-pYAIzeRo8J6KPEaJ0VWOh5Pzkbw/RetuzehGM7QRRX5he4fPHx2rdKMB256ehJCkX+XRQm16eZLqLNS8RSZXZw==",
+          "dev": true,
+          "requires": {
+            "ms": "^2.1.1"
+          }
+        },
+        "minimatch": {
+          "version": "3.0.4",
+          "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.4.tgz",
+          "integrity": "sha512-yJHVQEhyqPLUTgt9B83PXu6W3rx4MvvHvSUvToogpwoGDOUQ+yDrR0HRot+yOCdCO7u4hX3pWft6kWBBcqh0UA==",
+          "dev": true,
+          "requires": {
+            "brace-expansion": "^1.1.7"
+          }
+        },
+        "ms": {
+          "version": "2.1.2",
+          "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
+          "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w==",
+          "dev": true
+        }
+      }
+    },
+    "eslint-config-prettier": {
+      "version": "6.3.0",
+      "resolved": "https://registry.npmjs.org/eslint-config-prettier/-/eslint-config-prettier-6.3.0.tgz",
+      "integrity": "sha512-EWaGjlDAZRzVFveh2Jsglcere2KK5CJBhkNSa1xs3KfMUGdRiT7lG089eqPdvlzWHpAqaekubOsOMu8W8Yk71A==",
+      "dev": true,
+      "requires": {
+        "get-stdin": "^6.0.0"
+      }
+    },
+    "eslint-plugin-prettier": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/eslint-plugin-prettier/-/eslint-plugin-prettier-3.1.1.tgz",
+      "integrity": "sha512-A+TZuHZ0KU0cnn56/9mfR7/KjUJ9QNVXUhwvRFSR7PGPe0zQR6PTkmyqg1AtUUEOzTqeRsUwyKFh0oVZKVCrtA==",
+      "dev": true,
+      "requires": {
+        "prettier-linter-helpers": "^1.0.0"
+      }
+    },
+    "eslint-scope": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/eslint-scope/-/eslint-scope-5.0.0.tgz",
+      "integrity": "sha512-oYrhJW7S0bxAFDvWqzvMPRm6pcgcnWc4QnofCAqRTRfQC0JcwenzGglTtsLyIuuWFfkqDG9vz67cnttSd53djw==",
+      "dev": true,
+      "requires": {
+        "esrecurse": "^4.1.0",
+        "estraverse": "^4.1.1"
+      }
+    },
+    "eslint-utils": {
+      "version": "1.4.3",
+      "resolved": "https://registry.npmjs.org/eslint-utils/-/eslint-utils-1.4.3.tgz",
+      "integrity": "sha512-fbBN5W2xdY45KulGXmLHZ3c3FHfVYmKg0IrAKGOkT/464PQsx2UeIzfz1RmEci+KLm1bBaAzZAh8+/E+XAeZ8Q==",
+      "dev": true,
+      "requires": {
+        "eslint-visitor-keys": "^1.1.0"
+      }
+    },
+    "eslint-visitor-keys": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-1.1.0.tgz",
+      "integrity": "sha512-8y9YjtM1JBJU/A9Kc+SbaOV4y29sSWckBwMHa+FGtVj5gN/sbnKDf6xJUl+8g7FAij9LVaP8C24DUiH/f/2Z9A==",
+      "dev": true
+    },
+    "espree": {
+      "version": "6.1.2",
+      "resolved": "https://registry.npmjs.org/espree/-/espree-6.1.2.tgz",
+      "integrity": "sha512-2iUPuuPP+yW1PZaMSDM9eyVf8D5P0Hi8h83YtZ5bPc/zHYjII5khoixIUTMO794NOY8F/ThF1Bo8ncZILarUTA==",
+      "dev": true,
+      "requires": {
+        "acorn": "^7.1.0",
+        "acorn-jsx": "^5.1.0",
+        "eslint-visitor-keys": "^1.1.0"
+      },
+      "dependencies": {
+        "acorn": {
+          "version": "7.1.0",
+          "resolved": "https://registry.npmjs.org/acorn/-/acorn-7.1.0.tgz",
+          "integrity": "sha512-kL5CuoXA/dgxlBbVrflsflzQ3PAas7RYZB52NOm/6839iVYJgKMJ3cQJD+t2i5+qFa8h3MDpEOJiS64E8JLnSQ==",
+          "dev": true
+        }
+      }
+    },
+    "esprima": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/esprima/-/esprima-4.0.1.tgz",
+      "integrity": "sha512-eGuFFw7Upda+g4p+QHvnW0RyTX/SVeJBDM/gCtMARO0cLuT2HcEKnTPvhjV6aGeqrCB/sbNop0Kszm0jsaWU4A==",
+      "dev": true
+    },
+    "esquery": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/esquery/-/esquery-1.0.1.tgz",
+      "integrity": "sha512-SmiyZ5zIWH9VM+SRUReLS5Q8a7GxtRdxEBVZpm98rJM7Sb+A9DVCndXfkeFUd3byderg+EbDkfnevfCwynWaNA==",
+      "dev": true,
+      "requires": {
+        "estraverse": "^4.0.0"
+      }
+    },
+    "esrecurse": {
+      "version": "4.2.1",
+      "resolved": "https://registry.npmjs.org/esrecurse/-/esrecurse-4.2.1.tgz",
+      "integrity": "sha512-64RBB++fIOAXPw3P9cy89qfMlvZEXZkqqJkjqqXIvzP5ezRZjW+lPWjw35UX/3EhUPFYbg5ER4JYgDw4007/DQ==",
+      "dev": true,
+      "requires": {
+        "estraverse": "^4.1.0"
+      }
+    },
+    "estraverse": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/estraverse/-/estraverse-4.3.0.tgz",
+      "integrity": "sha512-39nnKffWz8xN1BU/2c79n9nB9HDzo0niYUqx6xyqUnyoAnQyyWpOTdZEeiCch8BBu515t4wp9ZmgVfVhn9EBpw==",
+      "dev": true
+    },
     "estree-walker": {
       "version": "0.6.1",
       "resolved": "https://registry.npmjs.org/estree-walker/-/estree-walker-0.6.1.tgz",
       "integrity": "sha512-SqmZANLWS0mnatqbSfRP5g8OXZC12Fgg1IwNtLsyHDzJizORW4khDfjPqJZsemPWBB2uqykUah5YpQ6epsqC/w==",
+      "dev": true
+    },
+    "esutils": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/esutils/-/esutils-2.0.3.tgz",
+      "integrity": "sha512-kVscqXk4OCp68SZ0dkgEKVi6/8ij300KBWTJq32P/dYeWTSwK41WyTxalN1eRmA5Z9UU/LX9D7FWSmV9SAYx6g==",
+      "dev": true
+    },
+    "external-editor": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/external-editor/-/external-editor-3.1.0.tgz",
+      "integrity": "sha512-hMQ4CX1p1izmuLYyZqLMO/qGNw10wSv9QDCPfzXfyFrOaCSSoRfqE1Kf1s5an66J5JZC62NewG+mK49jOCtQew==",
+      "dev": true,
+      "requires": {
+        "chardet": "^0.7.0",
+        "iconv-lite": "^0.4.24",
+        "tmp": "^0.0.33"
+      }
+    },
+    "fast-deep-equal": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-2.0.1.tgz",
+      "integrity": "sha1-ewUhjd+WZ79/Nwv3/bLLFf3Qqkk=",
+      "dev": true
+    },
+    "fast-diff": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/fast-diff/-/fast-diff-1.2.0.tgz",
+      "integrity": "sha512-xJuoT5+L99XlZ8twedaRf6Ax2TgQVxvgZOYoPKqZufmJib0tL2tegPBOZb1pVNgIhlqDlA0eO0c3wBvQcmzx4w==",
+      "dev": true
+    },
+    "fast-json-stable-stringify": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/fast-json-stable-stringify/-/fast-json-stable-stringify-2.0.0.tgz",
+      "integrity": "sha1-1RQsDK7msRifh9OnYREGT4bIu/I=",
+      "dev": true
+    },
+    "fast-levenshtein": {
+      "version": "2.0.6",
+      "resolved": "https://registry.npmjs.org/fast-levenshtein/-/fast-levenshtein-2.0.6.tgz",
+      "integrity": "sha1-PYpcZog6FqMMqGQ+hR8Zuqd5eRc=",
+      "dev": true
+    },
+    "figures": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/figures/-/figures-2.0.0.tgz",
+      "integrity": "sha1-OrGi0qYsi/tDGgyUy3l6L84nyWI=",
+      "dev": true,
+      "requires": {
+        "escape-string-regexp": "^1.0.5"
+      },
+      "dependencies": {
+        "escape-string-regexp": {
+          "version": "1.0.5",
+          "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",
+          "integrity": "sha1-G2HAViGQqN/2rjuyzwIAyhMLhtQ=",
+          "dev": true
+        }
+      }
+    },
+    "file-entry-cache": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/file-entry-cache/-/file-entry-cache-5.0.1.tgz",
+      "integrity": "sha512-bCg29ictuBaKUwwArK4ouCaqDgLZcysCFLmM/Yn/FDoqndh/9vNuQfXRDvTuXKLxfD/JtZQGKFT8MGcJBK644g==",
+      "dev": true,
+      "requires": {
+        "flat-cache": "^2.0.1"
+      }
+    },
+    "flat-cache": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/flat-cache/-/flat-cache-2.0.1.tgz",
+      "integrity": "sha512-LoQe6yDuUMDzQAEH8sgmh4Md6oZnc/7PjtwjNFSzveXqSHt6ka9fPBuso7IGf9Rz4uqnSnWiFH2B/zj24a5ReA==",
+      "dev": true,
+      "requires": {
+        "flatted": "^2.0.0",
+        "rimraf": "2.6.3",
+        "write": "1.0.3"
+      }
+    },
+    "flatted": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/flatted/-/flatted-2.0.1.tgz",
+      "integrity": "sha512-a1hQMktqW9Nmqr5aktAux3JMNqaucxGcjtjWnZLHX7yyPCmlSV3M54nGYbqT8K+0GhF3NBgmJCc3ma+WOgX8Jg==",
+      "dev": true
+    },
+    "fs.realpath": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz",
+      "integrity": "sha1-FQStJSMVjKpA20onh8sBQRmU6k8=",
+      "dev": true
+    },
+    "functional-red-black-tree": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/functional-red-black-tree/-/functional-red-black-tree-1.0.1.tgz",
+      "integrity": "sha1-GwqzvVU7Kg1jmdKcDj6gslIHgyc=",
+      "dev": true
+    },
+    "get-stdin": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/get-stdin/-/get-stdin-6.0.0.tgz",
+      "integrity": "sha512-jp4tHawyV7+fkkSKyvjuLZswblUtz+SQKzSWnBbii16BuZksJlU1wuBYXY75r+duh/llF1ur6oNwi+2ZzjKZ7g==",
       "dev": true
     },
     "glob": {
@@ -85,11 +558,73 @@
         "minimatch": "0.3"
       }
     },
+    "glob-parent": {
+      "version": "5.1.0",
+      "resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-5.1.0.tgz",
+      "integrity": "sha512-qjtRgnIVmOfnKUE3NJAQEdk+lKrxfw8t5ke7SXtfMTHcjsBfOfWXCQfdb30zfDoZQ2IRSIiidmjtbHZPZ++Ihw==",
+      "dev": true,
+      "requires": {
+        "is-glob": "^4.0.1"
+      }
+    },
+    "globals": {
+      "version": "11.12.0",
+      "resolved": "https://registry.npmjs.org/globals/-/globals-11.12.0.tgz",
+      "integrity": "sha512-WOBp/EEGUiIsJSp7wcv/y6MO+lV9UoncWqxuFfm8eBwzWNgyfBd6Gz+IeKQ9jCmyhoH99g15M3T+QaVHFjizVA==",
+      "dev": true
+    },
     "growl": {
       "version": "1.9.2",
       "resolved": "https://registry.npmjs.org/growl/-/growl-1.9.2.tgz",
       "integrity": "sha1-Dqd0NxXbjY3ixe3hd14bRayFwC8=",
       "dev": true
+    },
+    "has-flag": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-3.0.0.tgz",
+      "integrity": "sha1-tdRU3CGZriJWmfNGfloH87lVuv0=",
+      "dev": true
+    },
+    "iconv-lite": {
+      "version": "0.4.24",
+      "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.4.24.tgz",
+      "integrity": "sha512-v3MXnZAcvnywkTUEZomIActle7RXXeedOR31wwl7VlyoXO4Qi9arvSenNQWne1TcRwhCL1HwLI21bEqdpj8/rA==",
+      "dev": true,
+      "requires": {
+        "safer-buffer": ">= 2.1.2 < 3"
+      }
+    },
+    "ignore": {
+      "version": "4.0.6",
+      "resolved": "https://registry.npmjs.org/ignore/-/ignore-4.0.6.tgz",
+      "integrity": "sha512-cyFDKrqc/YdcWFniJhzI42+AzS+gNwmUzOSFcRCQYwySuBBBy/KjuxWLZ/FHEH6Moq1NizMOBWyTcv8O4OZIMg==",
+      "dev": true
+    },
+    "import-fresh": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/import-fresh/-/import-fresh-3.1.0.tgz",
+      "integrity": "sha512-PpuksHKGt8rXfWEr9m9EHIpgyyaltBy8+eF6GJM0QCAxMgxCfucMF3mjecK2QsJr0amJW7gTqh5/wht0z2UhEQ==",
+      "dev": true,
+      "requires": {
+        "parent-module": "^1.0.0",
+        "resolve-from": "^4.0.0"
+      }
+    },
+    "imurmurhash": {
+      "version": "0.1.4",
+      "resolved": "https://registry.npmjs.org/imurmurhash/-/imurmurhash-0.1.4.tgz",
+      "integrity": "sha1-khi5srkoojixPcT7a21XbyMUU+o=",
+      "dev": true
+    },
+    "inflight": {
+      "version": "1.0.6",
+      "resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.6.tgz",
+      "integrity": "sha1-Sb1jMdfQLQwJvJEKEHW6gWW1bfk=",
+      "dev": true,
+      "requires": {
+        "once": "^1.3.0",
+        "wrappy": "1"
+      }
     },
     "inherits": {
       "version": "2.0.4",
@@ -97,10 +632,58 @@
       "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==",
       "dev": true
     },
+    "inquirer": {
+      "version": "6.5.2",
+      "resolved": "https://registry.npmjs.org/inquirer/-/inquirer-6.5.2.tgz",
+      "integrity": "sha512-cntlB5ghuB0iuO65Ovoi8ogLHiWGs/5yNrtUcKjFhSSiVeAIVpD7koaSU9RM8mpXw5YDi9RdYXGQMaOURB7ycQ==",
+      "dev": true,
+      "requires": {
+        "ansi-escapes": "^3.2.0",
+        "chalk": "^2.4.2",
+        "cli-cursor": "^2.1.0",
+        "cli-width": "^2.0.0",
+        "external-editor": "^3.0.3",
+        "figures": "^2.0.0",
+        "lodash": "^4.17.12",
+        "mute-stream": "0.0.7",
+        "run-async": "^2.2.0",
+        "rxjs": "^6.4.0",
+        "string-width": "^2.1.0",
+        "strip-ansi": "^5.1.0",
+        "through": "^2.3.6"
+      }
+    },
+    "is-extglob": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/is-extglob/-/is-extglob-2.1.1.tgz",
+      "integrity": "sha1-qIwCU1eR8C7TfHahueqXc8gz+MI=",
+      "dev": true
+    },
+    "is-fullwidth-code-point": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-2.0.0.tgz",
+      "integrity": "sha1-o7MKXE8ZkYMWeqq5O+764937ZU8=",
+      "dev": true
+    },
+    "is-glob": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/is-glob/-/is-glob-4.0.1.tgz",
+      "integrity": "sha512-5G0tKtBTFImOqDnLB2hG6Bp2qcKEFduo4tZu9MT/H6NQv/ghhy30o55ufafxJ/LdH79LLs2Kfrn85TLKyA7BUg==",
+      "dev": true,
+      "requires": {
+        "is-extglob": "^2.1.1"
+      }
+    },
     "is-module": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/is-module/-/is-module-1.0.0.tgz",
       "integrity": "sha1-Mlj7afeMFNW4FdZkM2tM/7ZEFZE=",
+      "dev": true
+    },
+    "is-promise": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/is-promise/-/is-promise-2.1.0.tgz",
+      "integrity": "sha1-eaKp7OfwlugPNtKy87wWwf9L8/o=",
       "dev": true
     },
     "is-reference": {
@@ -112,10 +695,11 @@
         "@types/estree": "0.0.39"
       }
     },
-    "isobject": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/isobject/-/isobject-4.0.0.tgz",
-      "integrity": "sha512-S/2fF5wH8SJA/kmwr6HYhK/RI/OkhD84k8ntalo0iJjZikgq1XFvR5M8NPT1x5F7fBwCG3qHfnzeP/Vh/ZxCUA=="
+    "isexe": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz",
+      "integrity": "sha1-6PvzdNxVb/iUehDcsFctYz8s+hA=",
+      "dev": true
     },
     "jade": {
       "version": "0.26.3",
@@ -141,6 +725,50 @@
         }
       }
     },
+    "js-tokens": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-4.0.0.tgz",
+      "integrity": "sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==",
+      "dev": true
+    },
+    "js-yaml": {
+      "version": "3.13.1",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.13.1.tgz",
+      "integrity": "sha512-YfbcO7jXDdyj0DGxYVSlSeQNHbD7XPWvrVWeVUujrQEoZzWJIRrCPoyk6kL6IAjAG2IolMK4T0hNUe0HOUs5Jw==",
+      "dev": true,
+      "requires": {
+        "argparse": "^1.0.7",
+        "esprima": "^4.0.0"
+      }
+    },
+    "json-schema-traverse": {
+      "version": "0.4.1",
+      "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-0.4.1.tgz",
+      "integrity": "sha512-xbbCH5dCYU5T8LcEhhuh7HJ88HXuW3qsI3Y0zOZFKfZEHcpWiHU/Jxzk629Brsab/mMiHQti9wMP+845RPe3Vg==",
+      "dev": true
+    },
+    "json-stable-stringify-without-jsonify": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/json-stable-stringify-without-jsonify/-/json-stable-stringify-without-jsonify-1.0.1.tgz",
+      "integrity": "sha1-nbe1lJatPzz+8wp1FC0tkwrXJlE=",
+      "dev": true
+    },
+    "levn": {
+      "version": "0.3.0",
+      "resolved": "https://registry.npmjs.org/levn/-/levn-0.3.0.tgz",
+      "integrity": "sha1-OwmSTt+fCDwEkP3UwLxEIeBHZO4=",
+      "dev": true,
+      "requires": {
+        "prelude-ls": "~1.1.2",
+        "type-check": "~0.3.2"
+      }
+    },
+    "lodash": {
+      "version": "4.17.15",
+      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.15.tgz",
+      "integrity": "sha512-8xOcRHvCjnocdS5cpwXQXVzmmh5e5+saE2QGoeQmbKmRS6J3VQppPOIt0MnmE+4xlZoumy0GPG0D0MVIQbNA1A==",
+      "dev": true
+    },
     "lru-cache": {
       "version": "2.7.3",
       "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-2.7.3.tgz",
@@ -155,6 +783,12 @@
       "requires": {
         "sourcemap-codec": "^1.4.4"
       }
+    },
+    "mimic-fn": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/mimic-fn/-/mimic-fn-1.2.0.tgz",
+      "integrity": "sha512-jf84uxzwiuiIVKiOLpfYk7N46TSy8ubTonmneY9vrpHNAnp0QBt2BxWV9dO3/j+BoVAb+a5G6YDPW3M5HOdMWQ==",
+      "dev": true
     },
     "minimatch": {
       "version": "0.3.0",
@@ -205,10 +839,126 @@
       "integrity": "sha1-nNE8A62/8ltl7/3nzoZO6VIBcJg=",
       "dev": true
     },
+    "mute-stream": {
+      "version": "0.0.7",
+      "resolved": "https://registry.npmjs.org/mute-stream/-/mute-stream-0.0.7.tgz",
+      "integrity": "sha1-MHXOk7whuPq0PhvE2n6BFe0ee6s=",
+      "dev": true
+    },
+    "natural-compare": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/natural-compare/-/natural-compare-1.4.0.tgz",
+      "integrity": "sha1-Sr6/7tdUHywnrPspvbvRXI1bpPc=",
+      "dev": true
+    },
+    "nice-try": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/nice-try/-/nice-try-1.0.5.tgz",
+      "integrity": "sha512-1nh45deeb5olNY7eX82BkPO7SSxR5SSYJiPTrTdFUVYwAl8CKMA5N9PjTYkHiRjisVcxcQ1HXdLhx2qxxJzLNQ==",
+      "dev": true
+    },
+    "once": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
+      "integrity": "sha1-WDsap3WWHUsROsF9nFC6753Xa9E=",
+      "dev": true,
+      "requires": {
+        "wrappy": "1"
+      }
+    },
+    "onetime": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/onetime/-/onetime-2.0.1.tgz",
+      "integrity": "sha1-BnQoIw/WdEOyeUsiu6UotoZ5YtQ=",
+      "dev": true,
+      "requires": {
+        "mimic-fn": "^1.0.0"
+      }
+    },
+    "optionator": {
+      "version": "0.8.2",
+      "resolved": "https://registry.npmjs.org/optionator/-/optionator-0.8.2.tgz",
+      "integrity": "sha1-NkxeQJ0/TWMB1sC0wFu6UBgK62Q=",
+      "dev": true,
+      "requires": {
+        "deep-is": "~0.1.3",
+        "fast-levenshtein": "~2.0.4",
+        "levn": "~0.3.0",
+        "prelude-ls": "~1.1.2",
+        "type-check": "~0.3.2",
+        "wordwrap": "~1.0.0"
+      }
+    },
+    "os-tmpdir": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/os-tmpdir/-/os-tmpdir-1.0.2.tgz",
+      "integrity": "sha1-u+Z0BseaqFxc/sdm/lc0VV36EnQ=",
+      "dev": true
+    },
+    "parent-module": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/parent-module/-/parent-module-1.0.1.tgz",
+      "integrity": "sha512-GQ2EWRpQV8/o+Aw8YqtfZZPfNRWZYkbidE9k5rpl/hC3vtHHBfGm2Ifi6qWV+coDGkrUKZAxE3Lot5kcsRlh+g==",
+      "dev": true,
+      "requires": {
+        "callsites": "^3.0.0"
+      }
+    },
+    "path-is-absolute": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz",
+      "integrity": "sha1-F0uSaHNVNP+8es5r9TpanhtcX18=",
+      "dev": true
+    },
+    "path-key": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/path-key/-/path-key-2.0.1.tgz",
+      "integrity": "sha1-QRyttXTFoUDTpLGRDUDYDMn0C0A=",
+      "dev": true
+    },
     "path-parse": {
       "version": "1.0.6",
       "resolved": "https://registry.npmjs.org/path-parse/-/path-parse-1.0.6.tgz",
       "integrity": "sha512-GSmOT2EbHrINBf9SR7CDELwlJ8AENk3Qn7OikK4nFYAu3Ote2+JYNVvkpAEQm3/TLNEJFD/xZJjzyxg3KBWOzw==",
+      "dev": true
+    },
+    "prelude-ls": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/prelude-ls/-/prelude-ls-1.1.2.tgz",
+      "integrity": "sha1-IZMqVJ9eUv/ZqCf1cOBL5iqX2lQ=",
+      "dev": true
+    },
+    "prettier": {
+      "version": "1.18.2",
+      "resolved": "https://registry.npmjs.org/prettier/-/prettier-1.18.2.tgz",
+      "integrity": "sha512-OeHeMc0JhFE9idD4ZdtNibzY0+TPHSpSSb9h8FqtP+YnoZZ1sl8Vc9b1sasjfymH3SonAF4QcA2+mzHPhMvIiw==",
+      "dev": true
+    },
+    "prettier-linter-helpers": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/prettier-linter-helpers/-/prettier-linter-helpers-1.0.0.tgz",
+      "integrity": "sha512-GbK2cP9nraSSUF9N2XwUwqfzlAFlMNYYl+ShE/V+H8a9uNl/oUqB1w2EL54Jh0OlyRSd8RfWYJ3coVS4TROP2w==",
+      "dev": true,
+      "requires": {
+        "fast-diff": "^1.1.2"
+      }
+    },
+    "progress": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/progress/-/progress-2.0.3.tgz",
+      "integrity": "sha512-7PiHtLll5LdnKIMw100I+8xJXR5gW2QwWYkT6iJva0bXitZKa/XMrSbdmg3r2Xnaidz9Qumd0VPaMrZlF9V9sA==",
+      "dev": true
+    },
+    "punycode": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/punycode/-/punycode-2.1.1.tgz",
+      "integrity": "sha512-XRsRjdf+j5ml+y/6GKHPZbrF/8p2Yga0JPtdqTIY2Xe5ohJPD9saDJJLPvp9+NSBprVvevdXZybnj2cv8OEd0A==",
+      "dev": true
+    },
+    "regexpp": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/regexpp/-/regexpp-2.0.1.tgz",
+      "integrity": "sha512-lv0M6+TkDVniA3aD1Eg0DVpfU/booSu7Eev3TDO/mZKHBfVjgCGTV4t4buppESEYDtkArYFOxTJWv6S5C+iaNw==",
       "dev": true
     },
     "resolve": {
@@ -218,6 +968,56 @@
       "dev": true,
       "requires": {
         "path-parse": "^1.0.6"
+      }
+    },
+    "resolve-from": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/resolve-from/-/resolve-from-4.0.0.tgz",
+      "integrity": "sha512-pb/MYmXstAkysRFx8piNI1tGFNQIFA3vkE3Gq4EuA1dF6gHp/+vgZqsCGJapvy8N3Q+4o7FwvquPJcnZ7RYy4g==",
+      "dev": true
+    },
+    "restore-cursor": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/restore-cursor/-/restore-cursor-2.0.0.tgz",
+      "integrity": "sha1-n37ih/gv0ybU/RYpI9YhKe7g368=",
+      "dev": true,
+      "requires": {
+        "onetime": "^2.0.0",
+        "signal-exit": "^3.0.2"
+      }
+    },
+    "rimraf": {
+      "version": "2.6.3",
+      "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.6.3.tgz",
+      "integrity": "sha512-mwqeW5XsA2qAejG46gYdENaxXjx9onRNCfn7L0duuP4hCuTIi/QO7PDK07KJfp1d+izWPrzEJDcSqBa0OZQriA==",
+      "dev": true,
+      "requires": {
+        "glob": "^7.1.3"
+      },
+      "dependencies": {
+        "glob": {
+          "version": "7.1.5",
+          "resolved": "https://registry.npmjs.org/glob/-/glob-7.1.5.tgz",
+          "integrity": "sha512-J9dlskqUXK1OeTOYBEn5s8aMukWMwWfs+rPTn/jn50Ux4MNXVhubL1wu/j2t+H4NVI+cXEcCaYellqaPVGXNqQ==",
+          "dev": true,
+          "requires": {
+            "fs.realpath": "^1.0.0",
+            "inflight": "^1.0.4",
+            "inherits": "2",
+            "minimatch": "^3.0.4",
+            "once": "^1.3.0",
+            "path-is-absolute": "^1.0.0"
+          }
+        },
+        "minimatch": {
+          "version": "3.0.4",
+          "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.4.tgz",
+          "integrity": "sha512-yJHVQEhyqPLUTgt9B83PXu6W3rx4MvvHvSUvToogpwoGDOUQ+yDrR0HRot+yOCdCO7u4hX3pWft6kWBBcqh0UA==",
+          "dev": true,
+          "requires": {
+            "brace-expansion": "^1.1.7"
+          }
+        }
       }
     },
     "rollup": {
@@ -266,6 +1066,51 @@
         "estree-walker": "^0.6.1"
       }
     },
+    "run-async": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/run-async/-/run-async-2.3.0.tgz",
+      "integrity": "sha1-A3GrSuC91yDUFm19/aZP96RFpsA=",
+      "dev": true,
+      "requires": {
+        "is-promise": "^2.1.0"
+      }
+    },
+    "rxjs": {
+      "version": "6.5.3",
+      "resolved": "https://registry.npmjs.org/rxjs/-/rxjs-6.5.3.tgz",
+      "integrity": "sha512-wuYsAYYFdWTAnAaPoKGNhfpWwKZbJW+HgAJ+mImp+Epl7BG8oNWBCTyRM8gba9k4lk8BgWdoYm21Mo/RYhhbgA==",
+      "dev": true,
+      "requires": {
+        "tslib": "^1.9.0"
+      }
+    },
+    "safer-buffer": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/safer-buffer/-/safer-buffer-2.1.2.tgz",
+      "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==",
+      "dev": true
+    },
+    "semver": {
+      "version": "6.3.0",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.0.tgz",
+      "integrity": "sha512-b39TBaTSfV6yBrapU89p5fKekE2m/NwnDocOVruQFS1/veMgdzuPcnOM34M6CwxW8jH/lxEa5rBoDeUwu5HHTw==",
+      "dev": true
+    },
+    "shebang-command": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/shebang-command/-/shebang-command-1.2.0.tgz",
+      "integrity": "sha1-RKrGW2lbAzmJaMOfNj/uXer98eo=",
+      "dev": true,
+      "requires": {
+        "shebang-regex": "^1.0.0"
+      }
+    },
+    "shebang-regex": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/shebang-regex/-/shebang-regex-1.0.0.tgz",
+      "integrity": "sha1-2kL0l0DAtC2yypcoVxyxkMmO/qM=",
+      "dev": true
+    },
     "should": {
       "version": "7.1.1",
       "resolved": "https://registry.npmjs.org/should/-/should-7.1.1.tgz",
@@ -307,10 +1152,77 @@
       "integrity": "sha1-P/IfGYytIXX587eBhT/ZTQ0ZtZA=",
       "dev": true
     },
+    "signal-exit": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-3.0.2.tgz",
+      "integrity": "sha1-tf3AjxKH6hF4Yo5BXiUTK3NkbG0=",
+      "dev": true
+    },
+    "slice-ansi": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/slice-ansi/-/slice-ansi-2.1.0.tgz",
+      "integrity": "sha512-Qu+VC3EwYLldKa1fCxuuvULvSJOKEgk9pi8dZeCVK7TqBfUNTH4sFkk4joj8afVSfAYgJoSOetjx9QWOJ5mYoQ==",
+      "dev": true,
+      "requires": {
+        "ansi-styles": "^3.2.0",
+        "astral-regex": "^1.0.0",
+        "is-fullwidth-code-point": "^2.0.0"
+      }
+    },
     "sourcemap-codec": {
       "version": "1.4.4",
       "resolved": "https://registry.npmjs.org/sourcemap-codec/-/sourcemap-codec-1.4.4.tgz",
       "integrity": "sha512-CYAPYdBu34781kLHkaW3m6b/uUSyMOC2R61gcYMWooeuaGtjof86ZA/8T+qVPPt7np1085CR9hmMGrySwEc8Xg==",
+      "dev": true
+    },
+    "sprintf-js": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/sprintf-js/-/sprintf-js-1.0.3.tgz",
+      "integrity": "sha1-BOaSb2YolTVPPdAVIDYzuFcpfiw=",
+      "dev": true
+    },
+    "string-width": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/string-width/-/string-width-2.1.1.tgz",
+      "integrity": "sha512-nOqH59deCq9SRHlxq1Aw85Jnt4w6KvLKqWVik6oA9ZklXLNIOlqg4F2yrT1MVaTjAqvVwdfeZ7w7aCvJD7ugkw==",
+      "dev": true,
+      "requires": {
+        "is-fullwidth-code-point": "^2.0.0",
+        "strip-ansi": "^4.0.0"
+      },
+      "dependencies": {
+        "strip-ansi": {
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-4.0.0.tgz",
+          "integrity": "sha1-qEeQIusaw2iocTibY1JixQXuNo8=",
+          "dev": true,
+          "requires": {
+            "ansi-regex": "^3.0.0"
+          }
+        }
+      }
+    },
+    "strip-ansi": {
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-5.2.0.tgz",
+      "integrity": "sha512-DuRs1gKbBqsMKIZlrffwlug8MHkcnpjs5VPmL1PAh+mA30U0DTotfDZ0d2UUsXpPmPmMMJ6W773MaA3J+lbiWA==",
+      "dev": true,
+      "requires": {
+        "ansi-regex": "^4.1.0"
+      },
+      "dependencies": {
+        "ansi-regex": {
+          "version": "4.1.0",
+          "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-4.1.0.tgz",
+          "integrity": "sha512-1apePfXM1UOSqw0o9IiFAovVz9M5S1Dg+4TrDwfMewQ6p/rmMueb7tWZjQ1rx4Loy1ArBggoqGpfqqdI4rondg==",
+          "dev": true
+        }
+      }
+    },
+    "strip-json-comments": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-3.0.1.tgz",
+      "integrity": "sha512-VTyMAUfdm047mwKl+u79WIdrZxtFtn+nBxHeb844XBQ9uMNTuTHdx2hc5RiAJYqwTj3wc/xe5HLSdJSkJ+WfZw==",
       "dev": true
     },
     "supports-color": {
@@ -319,11 +1231,117 @@
       "integrity": "sha1-/x7R5hFp0Gs88tWI4YixjYhH4X4=",
       "dev": true
     },
+    "table": {
+      "version": "5.4.6",
+      "resolved": "https://registry.npmjs.org/table/-/table-5.4.6.tgz",
+      "integrity": "sha512-wmEc8m4fjnob4gt5riFRtTu/6+4rSe12TpAELNSqHMfF3IqnA+CH37USM6/YR3qRZv7e56kAEAtd6nKZaxe0Ug==",
+      "dev": true,
+      "requires": {
+        "ajv": "^6.10.2",
+        "lodash": "^4.17.14",
+        "slice-ansi": "^2.1.0",
+        "string-width": "^3.0.0"
+      },
+      "dependencies": {
+        "string-width": {
+          "version": "3.1.0",
+          "resolved": "https://registry.npmjs.org/string-width/-/string-width-3.1.0.tgz",
+          "integrity": "sha512-vafcv6KjVZKSgz06oM/H6GDBrAtz8vdhQakGjFIvNrHA6y3HCF1CInLy+QLq8dTJPQ1b+KDUqDFctkdRW44e1w==",
+          "dev": true,
+          "requires": {
+            "emoji-regex": "^7.0.1",
+            "is-fullwidth-code-point": "^2.0.0",
+            "strip-ansi": "^5.1.0"
+          }
+        }
+      }
+    },
+    "text-table": {
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/text-table/-/text-table-0.2.0.tgz",
+      "integrity": "sha1-f17oI66AUgfACvLfSoTsP8+lcLQ=",
+      "dev": true
+    },
+    "through": {
+      "version": "2.3.8",
+      "resolved": "https://registry.npmjs.org/through/-/through-2.3.8.tgz",
+      "integrity": "sha1-DdTJ/6q8NXlgsbckEV1+Doai4fU=",
+      "dev": true
+    },
+    "tmp": {
+      "version": "0.0.33",
+      "resolved": "https://registry.npmjs.org/tmp/-/tmp-0.0.33.tgz",
+      "integrity": "sha512-jRCJlojKnZ3addtTOjdIqoRuPEKBvNXcGYqzO6zWZX8KfKEpnGY5jfggJQ3EjKuu8D4bJRr0y+cYJFmYbImXGw==",
+      "dev": true,
+      "requires": {
+        "os-tmpdir": "~1.0.2"
+      }
+    },
     "to-iso-string": {
       "version": "0.0.2",
       "resolved": "https://registry.npmjs.org/to-iso-string/-/to-iso-string-0.0.2.tgz",
       "integrity": "sha1-TcGeZk38y+Jb2NtQiwDG2hWCVdE=",
       "dev": true
+    },
+    "tslib": {
+      "version": "1.10.0",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.10.0.tgz",
+      "integrity": "sha512-qOebF53frne81cf0S9B41ByenJ3/IuH8yJKngAX35CmiZySA0khhkovshKK+jGCaMnVomla7gVlIcc3EvKPbTQ==",
+      "dev": true
+    },
+    "type-check": {
+      "version": "0.3.2",
+      "resolved": "https://registry.npmjs.org/type-check/-/type-check-0.3.2.tgz",
+      "integrity": "sha1-WITKtRLPHTVeP7eE8wgEsrUg23I=",
+      "dev": true,
+      "requires": {
+        "prelude-ls": "~1.1.2"
+      }
+    },
+    "uri-js": {
+      "version": "4.2.2",
+      "resolved": "https://registry.npmjs.org/uri-js/-/uri-js-4.2.2.tgz",
+      "integrity": "sha512-KY9Frmirql91X2Qgjry0Wd4Y+YTdrdZheS8TFwvkbLWf/G5KNJDCh6pKL5OZctEW4+0Baa5idK2ZQuELRwPznQ==",
+      "dev": true,
+      "requires": {
+        "punycode": "^2.1.0"
+      }
+    },
+    "v8-compile-cache": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/v8-compile-cache/-/v8-compile-cache-2.1.0.tgz",
+      "integrity": "sha512-usZBT3PW+LOjM25wbqIlZwPeJV+3OSz3M1k1Ws8snlW39dZyYL9lOGC5FgPVHfk0jKmjiDV8Z0mIbVQPiwFs7g==",
+      "dev": true
+    },
+    "which": {
+      "version": "1.3.1",
+      "resolved": "https://registry.npmjs.org/which/-/which-1.3.1.tgz",
+      "integrity": "sha512-HxJdYWq1MTIQbJ3nw0cqssHoTNU267KlrDuGZ1WYlxDStUtKUhOaJmh112/TZmHxxUfuJqPXSOm7tDyas0OSIQ==",
+      "dev": true,
+      "requires": {
+        "isexe": "^2.0.0"
+      }
+    },
+    "wordwrap": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/wordwrap/-/wordwrap-1.0.0.tgz",
+      "integrity": "sha1-J1hIEIkUVqQXHI0CJkQa3pDLyus=",
+      "dev": true
+    },
+    "wrappy": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
+      "integrity": "sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8=",
+      "dev": true
+    },
+    "write": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/write/-/write-1.0.3.tgz",
+      "integrity": "sha512-/lg70HAjtkUgWPVZhZcm+T4hkL8Zbtp1nFNOn3lRrxnlv50SRBv7cR7RqR+GMsd3hUXy9hWBo4CHTbFTcOYwig==",
+      "dev": true,
+      "requires": {
+        "mkdirp": "^0.5.1"
+      }
     }
   }
 }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@mparticle/web-google-analytics-kit",
-    "version": "2.0.0-rc.2",
+    "version": "2.0.1-rc.1",
     "author": "mParticle Developers <developers@mparticle.com> (https://www.mparticle.com)",
     "description": "mParticle integration sdk for Google Analytics",
     "browser": "dist/GoogleAnalyticsEventForwarder.common.js",
@@ -17,10 +17,14 @@
         "mocha": "^2.3.2",
         "rollup": "^1.13.1",
         "rollup-plugin-commonjs": "^10.0.0",
-        "rollup-plugin-node-resolve": "^5.0.1"
+        "rollup-plugin-node-resolve": "^5.0.1",
+        "eslint": "^6.4.0",
+        "eslint-config-prettier": "6.3.0",
+        "eslint-plugin-prettier": "3.1.1",
+        "prettier": "1.18.2"
     },
     "dependencies": {
-        "@mparticle/web-sdk": "^2.9.4-rc.1"
+        "@mparticle/web-sdk": "^2.9.13-rc.1"
     },
     "license": "Apache-2.0"
 }

--- a/package.json
+++ b/package.json
@@ -1,27 +1,26 @@
 {
-  "name": "@mparticle/web-google-analytics-kit",
-  "version": "2.0.0-rc.2",
-  "author": "mParticle Developers <developers@mparticle.com> (https://www.mparticle.com)",
-  "description": "mParticle integration sdk for Google Analytics",
-  "browser": "dist/GoogleAnalyticsEventForwarder.common.js",
-  "files": [
-    "dist/GoogleAnalyticsEventForwarder.common.js"
-  ],
-  "repository": "https://github.com/mparticle-integrations/mparticle-javascript-integration-google-analytics",
-  "scripts": {
-    "build": "rollup --config rollup.config.js",
-    "watch": "rollup --config rollup.config.js -w"
-  },
-  "devDependencies": {
-    "should": "^7.1.0",
-    "mocha": "^2.3.2",
-    "rollup": "^1.13.1",
-    "rollup-plugin-commonjs": "^10.0.0",
-    "rollup-plugin-node-resolve": "^5.0.1"
-  },
-  "dependencies": {
-    "isobject": "^4.0.0",
-    "@mparticle/web-sdk": "^2.9.4-rc.1"
-  },
-  "license": "Apache-2.0"
+    "name": "@mparticle/web-google-analytics-kit",
+    "version": "2.0.0-rc.2",
+    "author": "mParticle Developers <developers@mparticle.com> (https://www.mparticle.com)",
+    "description": "mParticle integration sdk for Google Analytics",
+    "browser": "dist/GoogleAnalyticsEventForwarder.common.js",
+    "files": [
+        "dist/GoogleAnalyticsEventForwarder.common.js"
+    ],
+    "repository": "https://github.com/mparticle-integrations/mparticle-javascript-integration-google-analytics",
+    "scripts": {
+        "build": "rollup --config rollup.config.js",
+        "watch": "rollup --config rollup.config.js -w"
+    },
+    "devDependencies": {
+        "should": "^7.1.0",
+        "mocha": "^2.3.2",
+        "rollup": "^1.13.1",
+        "rollup-plugin-commonjs": "^10.0.0",
+        "rollup-plugin-node-resolve": "^5.0.1"
+    },
+    "dependencies": {
+        "@mparticle/web-sdk": "^2.9.4-rc.1"
+    },
+    "license": "Apache-2.0"
 }

--- a/src/GoogleAnalyticsEventForwarder.js
+++ b/src/GoogleAnalyticsEventForwarder.js
@@ -14,8 +14,6 @@
 //  See the License for the specific language governing permissions and
 //  limitations under the License.
 
-    var isobject = require('isobject');
-
     var name = 'GoogleAnalyticsEventForwarder',
         moduleId = 6,
         MessageType = {
@@ -38,7 +36,6 @@
     var constructor = function() {
         var self = this,
             isInitialized = false,
-            isEcommerceLoaded = false,
             isEnhancedEcommerceLoaded = false,
             forwarderSettings,
             reportingService,
@@ -87,18 +84,18 @@
         }
 
         function applyCustomDimensionsMetricsForSourceAttributes(attributes, targetDimensionsAndMetrics, mapLevel) {
-            for (var cdKey in mapLevel.customDimensions) {
+            for (var customDimension in mapLevel.customDimensions) {
                 for (attrName in attributes) {
-                    if (mapLevel.customDimensions[cdKey] === attrName) {
-                        targetDimensionsAndMetrics[cdKey] = attributes[attrName];
+                    if (customDimension === attrName) {
+                        targetDimensionsAndMetrics[mapLevel.customDimensions[customDimension]] = attributes[attrName];
                     }
                 }
             }
 
-            for (var cmKey in mapLevel.customMetrics) {
+            for (var customMetric in mapLevel.customMetrics) {
                 for (attrName in attributes) {
-                    if (mapLevel.customMetrics[cmKey] === attrName) {
-                        targetDimensionsAndMetrics[cmKey] = attributes[attrName];
+                    if (customMetric === attrName) {
+                        targetDimensionsAndMetrics[mapLevel.customMetrics[customMetric]] = attributes[attrName];
                     }
                 }
             }
@@ -402,13 +399,6 @@
             }
         }
 
-        function checkForDuplicateMapping(dimensionOrMetric, eventLevelMap) {
-            var existingMapper = eventLevelMap['customDimensions'][formatDimensionOrMetric(dimensionOrMetric.value)];
-            if (existingMapper) {
-                console.log('Warning: both ' + existingMapper + ' & ' + dimensionOrMetric.map + ' are mapped to ' + dimensionOrMetric.value + '. ' + dimensionOrMetric.map + ' is replacing ' + existingMapper + '. If this is a mistake, please revisit the Google Analytics settings at app.mparticle.com. Otherwise, please ignore this warning.');
-            }
-        }
-
         function initForwarder(settings, service, testMode, tid) {
             try {
                 forwarderSettings = settings;
@@ -479,14 +469,11 @@
                         var customDimensions = JSON.parse(forwarderSettings.customDimensions.replace(/&quot;/g, '\"'));
                         customDimensions.forEach(function(dimension) {
                             if (dimension.maptype === 'EventAttributeClass.Name') {
-                                checkForDuplicateMapping(dimension, eventLevelMap);
-                                eventLevelMap['customDimensions'][formatDimensionOrMetric(dimension.value)] = dimension.map;
+                                eventLevelMap['customDimensions'][dimension.map] = formatDimensionOrMetric(dimension.value);
                             } else if (dimension.maptype === 'UserAttributeClass.Name') {
-                                checkForDuplicateMapping(dimension, userLevelMap);
-                                userLevelMap['customDimensions'][formatDimensionOrMetric(dimension.value)] = dimension.map;
+                                userLevelMap['customDimensions'][dimension.map] = formatDimensionOrMetric(dimension.value);
                             } else if (dimension.maptype === 'ProductAttributeSelector.Name') {
-                                checkForDuplicateMapping(dimension, productLevelMap);
-                                productLevelMap['customDimensions'][formatDimensionOrMetric(dimension.value)] = dimension.map;
+                                productLevelMap['customDimensions'][dimension.map] = formatDimensionOrMetric(dimension.value);
                             }
                         });
                     }
@@ -495,14 +482,11 @@
                         var customMetrics = JSON.parse(forwarderSettings.customMetrics.replace(/&quot;/g, '\"'));
                         customMetrics.forEach(function(metric) {
                             if (metric.maptype === 'EventAttributeClass.Name') {
-                                checkForDuplicateMapping(metric, eventLevelMap);
-                                eventLevelMap['customMetrics'][formatDimensionOrMetric(metric.value)] = metric.map;
+                                eventLevelMap['customMetrics'][metric.map] = formatDimensionOrMetric(metric.value);
                             } else if (metric.maptype === 'UserAttributeClass.Name') {
-                                checkForDuplicateMapping(metric, userLevelMap);
-                                userLevelMap['customMetrics'][formatDimensionOrMetric(metric.value)] = metric.map;
+                                userLevelMap['customMetrics'][metric.map] = formatDimensionOrMetric(metric.value);
                             } else if (metric.maptype === 'ProductAttributeSelector.Name') {
-                                checkForDuplicateMapping(metric, productLevelMap);
-                                productLevelMap['customMetrics'][formatDimensionOrMetric(metric.value)] = metric.map;
+                                productLevelMap['customMetrics'][metric.map] = formatDimensionOrMetric(metric.value);
                             }
                         });
                     }
@@ -525,18 +509,22 @@
         return moduleId;
     }
 
+    function isObject(val) {
+        return val != null && typeof val === 'object' && Array.isArray(val) === false;
+    }
+
     function register(config) {
         if (!config) {
             window.console.log('You must pass a config object to register the kit ' + name);
             return;
         }
 
-        if (!isobject(config)) {
+        if (!isObject(config)) {
             window.console.log('\'config\' must be an object. You passed in a ' + typeof config);
             return;
         }
 
-        if (isobject(config.kits)) {
+        if (isObject(config.kits)) {
             config.kits[name] = {
                 constructor: constructor
             };

--- a/src/GoogleAnalyticsEventForwarder.js
+++ b/src/GoogleAnalyticsEventForwarder.js
@@ -16,6 +16,7 @@
 
     var name = 'GoogleAnalyticsEventForwarder',
         moduleId = 6,
+        version = '2.0.1',
         MessageType = {
             SessionStart: 1,
             SessionEnd: 2,
@@ -546,5 +547,8 @@
     }
 
     module.exports = {
-        register: register
+        register: register,
+        getVersion: function() {
+            return version;
+        }
     };

--- a/test/tests.js
+++ b/test/tests.js
@@ -1,6 +1,6 @@
 /* eslint-disable no-undef*/
 
-describe('Google Analytics Forwarder', function () {
+describe('Google Analytics Forwarder', function() {
     var MessageType = {
             SessionStart: 1,
             SessionEnd: 2,
@@ -8,7 +8,7 @@ describe('Google Analytics Forwarder', function () {
             PageEvent: 4,
             CrashReport: 5,
             OptOut: 6,
-            Commerce: 16
+            Commerce: 16,
         },
         EventType = {
             Unknown: 0,
@@ -21,9 +21,9 @@ describe('Google Analytics Forwarder', function () {
             Social: 7,
             Other: 8,
             Media: 9,
-            getName: function () {
+            getName: function() {
                 return 'blahblah';
-            }
+            },
         },
         ProductActionType = {
             Unknown: 0,
@@ -36,7 +36,7 @@ describe('Google Analytics Forwarder', function () {
             Purchase: 7,
             Refund: 8,
             AddToWishlist: 9,
-            RemoveFromWishlist: 10
+            RemoveFromWishlist: 10,
         },
         IdentityType = {
             Other: 0,
@@ -49,32 +49,34 @@ describe('Google Analytics Forwarder', function () {
             Email: 7,
             Alias: 8,
             FacebookCustomAudienceId: 9,
-            getName: function () {return 'CustomerID';}
+            getName: function() {
+                return 'CustomerID';
+            },
         },
         PromotionActionType = {
             Unknown: 0,
             PromotionView: 1,
-            PromotionClick: 2
+            PromotionClick: 2,
         },
-        ReportingService = function () {
+        ReportingService = function() {
             var self = this;
 
             this.id = null;
             this.event = null;
 
-            this.cb = function (forwarder, event) {
+            this.cb = function(forwarder, event) {
                 self.id = forwarder.id;
                 self.event = event;
             };
 
-            this.reset = function () {
+            this.reset = function() {
                 this.id = null;
                 this.event = null;
             };
         },
         reportService = new ReportingService();
 
-    before(function () {
+    before(function() {
         mParticle.init('testAPI');
         mParticle.EventType = EventType;
         mParticle.ProductActionType = ProductActionType;
@@ -92,7 +94,10 @@ describe('Google Analytics Forwarder', function () {
             name = name.toString().toLowerCase();
 
             if (Array.prototype.reduce) {
-                return name.split('').reduce(function (a, b) { a = ((a << 5) - a) + b.charCodeAt(0); return a & a; }, 0);
+                return name.split('').reduce(function(a, b) {
+                    a = (a << 5) - a + b.charCodeAt(0);
+                    return a & a;
+                }, 0);
             }
 
             if (name.length === 0) {
@@ -101,7 +106,7 @@ describe('Google Analytics Forwarder', function () {
 
             for (i = 0; i < name.length; i++) {
                 character = name.charCodeAt(i);
-                hash = ((hash << 5) - hash) + character;
+                hash = (hash << 5) - hash + character;
                 hash = hash & hash;
             }
 
@@ -110,17 +115,24 @@ describe('Google Analytics Forwarder', function () {
     });
 
     beforeEach(function() {
-        mParticle.forwarder.init({
-            useCustomerId: 'True',
-            customDimensions:'[{ \
+        mParticle.forwarder.init(
+            {
+                useCustomerId: 'True',
+                customDimensions:
+                    '[{ \
                 &quot;maptype&quot;:&quot;EventAttributeClass.Name&quot;,&quot;value&quot;:&quot;Dimension 1&quot;,&quot;map&quot;:&quot;color&quot;},{&quot;maptype&quot;:&quot;EventAttributeClass.Name&quot;,&quot;value&quot;:&quot;Dimension 2&quot;,&quot;map&quot;:&quot;gender&quot;},{&quot;maptype&quot;:&quot;EventAttributeClass.Name&quot;,&quot;value&quot;:&quot;Dimension 3&quot;,&quot;map&quot;:&quot;size&quot;}, \
                 {&quot;maptype&quot;:&quot;ProductAttributeSelector.Name&quot;,&quot;value&quot;:&quot;Dimension 1&quot;,&quot;map&quot;:&quot;color&quot;},{&quot;maptype&quot;:&quot;ProductAttributeSelector.Name&quot;,&quot;value&quot;:&quot;Dimension 2&quot;,&quot;map&quot;:&quot;gender&quot;},{&quot;maptype&quot;:&quot;ProductAttributeSelector.Name&quot;,&quot;value&quot;:&quot;Dimension 3&quot;,&quot;map&quot;:&quot;size&quot;}, \
                 {&quot;maptype&quot;:&quot;UserAttributeClass.Name&quot;,&quot;value&quot;:&quot;Dimension 1&quot;,&quot;map&quot;:&quot;color&quot;},{&quot;maptype&quot;:&quot;UserAttributeClass.Name&quot;,&quot;value&quot;:&quot;Dimension 2&quot;,&quot;map&quot;:&quot;gender&quot;},{&quot;maptype&quot;:&quot;UserAttributeClass.Name&quot;,&quot;value&quot;:&quot;Dimension 3&quot;,&quot;map&quot;:&quot;size&quot;}]',
 
-            customMetrics:'[{&quot;maptype&quot;:&quot;EventAttributeClass.Name&quot;,&quot;value&quot;:&quot;Metric 1&quot;,&quot;map&quot;:&quot;levels&quot;},{&quot;maptype&quot;:&quot;EventAttributeClass.Name&quot;,&quot;value&quot;:&quot;Metric 2&quot;,&quot;map&quot;:&quot;shots&quot;},{&quot;maptype&quot;:&quot;EventAttributeClass.Name&quot;,&quot;value&quot;:&quot;Metric 3&quot;,&quot;map&quot;:&quot;players&quot;}, \
+                customMetrics:
+                    '[{&quot;maptype&quot;:&quot;EventAttributeClass.Name&quot;,&quot;value&quot;:&quot;Metric 1&quot;,&quot;map&quot;:&quot;levels&quot;},{&quot;maptype&quot;:&quot;EventAttributeClass.Name&quot;,&quot;value&quot;:&quot;Metric 2&quot;,&quot;map&quot;:&quot;shots&quot;},{&quot;maptype&quot;:&quot;EventAttributeClass.Name&quot;,&quot;value&quot;:&quot;Metric 3&quot;,&quot;map&quot;:&quot;players&quot;}, \
                 {&quot;maptype&quot;:&quot;ProductAttributeSelector.Name&quot;,&quot;value&quot;:&quot;Metric 1&quot;,&quot;map&quot;:&quot;levels&quot;},{&quot;maptype&quot;:&quot;ProductAttributeSelector.Name&quot;,&quot;value&quot;:&quot;Metric 2&quot;,&quot;map&quot;:&quot;shots&quot;},{&quot;maptype&quot;:&quot;ProductAttributeSelector.Name&quot;,&quot;value&quot;:&quot;Metric 3&quot;,&quot;map&quot;:&quot;players&quot;}, \
-                {&quot;maptype&quot;:&quot;UserAttributeClass.Name&quot;,&quot;value&quot;:&quot;Metric 1&quot;,&quot;map&quot;:&quot;levels&quot;},{&quot;maptype&quot;:&quot;UserAttributeClass.Name&quot;,&quot;value&quot;:&quot;Metric 2&quot;,&quot;map&quot;:&quot;shots&quot;},{&quot;maptype&quot;:&quot;UserAttributeClass.Name&quot;,&quot;value&quot;:&quot;Metric 3&quot;,&quot;map&quot;:&quot;players&quot;}]'
-        }, reportService.cb, true, 'tracker-name');
+                {&quot;maptype&quot;:&quot;UserAttributeClass.Name&quot;,&quot;value&quot;:&quot;Metric 1&quot;,&quot;map&quot;:&quot;levels&quot;},{&quot;maptype&quot;:&quot;UserAttributeClass.Name&quot;,&quot;value&quot;:&quot;Metric 2&quot;,&quot;map&quot;:&quot;shots&quot;},{&quot;maptype&quot;:&quot;UserAttributeClass.Name&quot;,&quot;value&quot;:&quot;Metric 3&quot;,&quot;map&quot;:&quot;players&quot;}]',
+            },
+            reportService.cb,
+            true,
+            'tracker-name'
+        );
         window.googleanalytics.reset();
         window._gaq = [];
     });
@@ -128,13 +140,25 @@ describe('Google Analytics Forwarder', function () {
     it('should initialize with ampClientId if clientIdentificationType is AMP', function(done) {
         window.googleanalytics.reset();
 
-        mParticle.forwarder.init({
-            clientIdentificationType: 'AMP'
-        }, reportService.cb, true, 'tracker-name');
+        mParticle.forwarder.init(
+            {
+                clientIdentificationType: 'AMP',
+            },
+            reportService.cb,
+            true,
+            'tracker-name'
+        );
 
         window.googleanalytics.args[0][0].should.equal('create');
-        window.googleanalytics.args[0][1].should.have.properties('name', 'trackingId', 'useAmpClientId');
-        window.googleanalytics.args[0][1].should.have.property('useAmpClientId', true);
+        window.googleanalytics.args[0][1].should.have.properties(
+            'name',
+            'trackingId',
+            'useAmpClientId'
+        );
+        window.googleanalytics.args[0][1].should.have.property(
+            'useAmpClientId',
+            true
+        );
 
         done();
     });
@@ -144,11 +168,11 @@ describe('Google Analytics Forwarder', function () {
             EventDataType: MessageType.PageView,
             EventName: 'Test Page Event',
             EventAttributes: {
-                anything: 'foo'
+                anything: 'foo',
             },
             CustomFlags: {
-                'Google.Page': 'foo page'
-            }
+                'Google.Page': 'foo page',
+            },
         });
 
         window.googleanalytics.args[0][0].should.equal('tracker-name.set');
@@ -171,8 +195,8 @@ describe('Google Analytics Forwarder', function () {
                 size: 'large',
                 levels: 1,
                 shots: 15,
-                players: 3
-            }
+                players: 3,
+            },
         };
 
         mParticle.forwarder.process(event);
@@ -183,16 +207,25 @@ describe('Google Analytics Forwarder', function () {
         window.googleanalytics.args[0][3].should.equal('Test Event');
         window.googleanalytics.args[0][4].should.equal('label');
         window.googleanalytics.args[0][5].should.equal(200);
-        window.googleanalytics.args[0][6].should.have.property('dimension1', 'blue');
-        window.googleanalytics.args[0][6].should.have.property('dimension2', 'female');
-        window.googleanalytics.args[0][6].should.have.property('dimension3', 'large');
+        window.googleanalytics.args[0][6].should.have.property(
+            'dimension1',
+            'blue'
+        );
+        window.googleanalytics.args[0][6].should.have.property(
+            'dimension2',
+            'female'
+        );
+        window.googleanalytics.args[0][6].should.have.property(
+            'dimension3',
+            'large'
+        );
         window.googleanalytics.args[0][6].should.have.property('metric1', 1);
         window.googleanalytics.args[0][6].should.have.property('metric2', 15);
         window.googleanalytics.args[0][6].should.have.property('metric3', 3);
 
         window.googleanalytics.args = [];
 
-        event.CustomFlags = { 'Google.HitType': 'abcdef'};
+        event.CustomFlags = { 'Google.HitType': 'abcdef' };
 
         mParticle.forwarder.process(event);
         window.googleanalytics.args[0][1].should.equal('abcdef');
@@ -221,40 +254,65 @@ describe('Google Analytics Forwarder', function () {
                             size: 'large',
                             levels: 1,
                             shots: 15,
-                            players: 3
-                        }
-                    }
+                            players: 3,
+                        },
+                    },
                 ],
                 TransactionId: 123,
                 Affiliation: 'my-affiliation',
                 TotalAmount: 450,
                 TaxAmount: 40,
                 ShippingAmount: 10,
-                CouponCode: null
-            }
+                CouponCode: null,
+            },
         };
         mParticle.forwarder.process(event);
 
-        window.googleanalytics.args[1][0].should.equal('tracker-name.ec:addProduct');
+        window.googleanalytics.args[1][0].should.equal(
+            'tracker-name.ec:addProduct'
+        );
         window.googleanalytics.args[1][1].should.have.property('id', '12345');
-        window.googleanalytics.args[1][1].should.have.property('name', 'iPhone 6');
-        window.googleanalytics.args[1][1].should.have.property('category', 'Phones');
-        window.googleanalytics.args[1][1].should.have.property('brand', 'iPhone');
+        window.googleanalytics.args[1][1].should.have.property(
+            'name',
+            'iPhone 6'
+        );
+        window.googleanalytics.args[1][1].should.have.property(
+            'category',
+            'Phones'
+        );
+        window.googleanalytics.args[1][1].should.have.property(
+            'brand',
+            'iPhone'
+        );
         window.googleanalytics.args[1][1].should.have.property('variant', '6');
         window.googleanalytics.args[1][1].should.have.property('price', 400);
         window.googleanalytics.args[1][1].should.have.property('coupon', null);
         window.googleanalytics.args[1][1].should.have.property('quantity', 1);
-        window.googleanalytics.args[1][1].should.have.property('dimension1', 'blue');
-        window.googleanalytics.args[1][1].should.have.property('dimension2', 'female');
-        window.googleanalytics.args[1][1].should.have.property('dimension3', 'large');
+        window.googleanalytics.args[1][1].should.have.property(
+            'dimension1',
+            'blue'
+        );
+        window.googleanalytics.args[1][1].should.have.property(
+            'dimension2',
+            'female'
+        );
+        window.googleanalytics.args[1][1].should.have.property(
+            'dimension3',
+            'large'
+        );
         window.googleanalytics.args[1][1].should.have.property('metric1', 1);
         window.googleanalytics.args[1][1].should.have.property('metric2', 15);
         window.googleanalytics.args[1][1].should.have.property('metric3', 3);
 
-        window.googleanalytics.args[2][0].should.equal('tracker-name.ec:setAction');
+        window.googleanalytics.args[2][0].should.equal(
+            'tracker-name.ec:setAction'
+        );
         window.googleanalytics.args[2][1].should.equal('purchase');
         window.googleanalytics.args[2][2].should.have.property('id', 123);
-        window.googleanalytics.args[2][2].should.have.property('affiliation', 'my-affiliation');
+        window.googleanalytics.args[2][2].should.have.property(
+            'affiliation',
+            'my-affiliation'
+        );
         window.googleanalytics.args[2][2].should.have.property('revenue', 450);
         window.googleanalytics.args[2][2].should.have.property('tax', 40);
         window.googleanalytics.args[2][2].should.have.property('shipping', 10);
@@ -267,7 +325,7 @@ describe('Google Analytics Forwarder', function () {
 
         window.googleanalytics.args = [];
 
-        event.CustomFlags = { 'Google.HitType': 'abcdef'};
+        event.CustomFlags = { 'Google.HitType': 'abcdef' };
         mParticle.forwarder.process(event);
         window.googleanalytics.args[2][1].should.equal('abcdef');
 
@@ -284,9 +342,9 @@ describe('Google Analytics Forwarder', function () {
                         Id: 12345,
                         Creative: 'my creative',
                         Name: 'Test promotion',
-                        Position: 3
-                    }
-                ]
+                        Position: 3,
+                    },
+                ],
             },
             UserAttributes: {
                 gender: 'female',
@@ -294,13 +352,22 @@ describe('Google Analytics Forwarder', function () {
                 size: 'large',
                 levels: 1,
                 shots: 15,
-                players: 3
-            }
+                players: 3,
+            },
         });
 
-        window.googleanalytics.args[1][4].should.have.property('dimension1', 'blue');
-        window.googleanalytics.args[1][4].should.have.property('dimension2', 'female');
-        window.googleanalytics.args[1][4].should.have.property('dimension3', 'large');
+        window.googleanalytics.args[1][4].should.have.property(
+            'dimension1',
+            'blue'
+        );
+        window.googleanalytics.args[1][4].should.have.property(
+            'dimension2',
+            'female'
+        );
+        window.googleanalytics.args[1][4].should.have.property(
+            'dimension3',
+            'large'
+        );
         window.googleanalytics.args[1][4].should.have.property('metric1', 1);
         window.googleanalytics.args[1][4].should.have.property('metric2', 15);
         window.googleanalytics.args[1][4].should.have.property('metric3', 3);
@@ -317,16 +384,19 @@ describe('Google Analytics Forwarder', function () {
                         Id: 12345,
                         Creative: 'my creative',
                         Name: 'Test promotion',
-                        Position: 3
-                    }
-                ]
+                        Position: 3,
+                    },
+                ],
             },
             CustomFlags: {
-                'Google.NonInteraction': true
-            }
+                'Google.NonInteraction': true,
+            },
         });
 
-        window.googleanalytics.args[1][4].should.have.property('nonInteraction', true);
+        window.googleanalytics.args[1][4].should.have.property(
+            'nonInteraction',
+            true
+        );
 
         done();
     });
@@ -338,8 +408,8 @@ describe('Google Analytics Forwarder', function () {
             EventAttributes: {
                 label: 'label',
                 value: 200,
-                category: 'category'
-            }
+                category: 'category',
+            },
         });
 
         window.googleanalytics.args[0][0].should.equal('tracker-name.send');
@@ -354,7 +424,7 @@ describe('Google Analytics Forwarder', function () {
 
     it('should log page view', function(done) {
         var event = {
-            EventDataType: MessageType.PageView
+            EventDataType: MessageType.PageView,
         };
         mParticle.forwarder.process(event);
 
@@ -363,7 +433,7 @@ describe('Google Analytics Forwarder', function () {
 
         window.googleanalytics.args = [];
 
-        event.CustomFlags = { 'Google.HitType': 'abcdef'};
+        event.CustomFlags = { 'Google.HitType': 'abcdef' };
         mParticle.forwarder.process(event);
         window.googleanalytics.args[0][1].should.equal('abcdef');
 
@@ -384,32 +454,48 @@ describe('Google Analytics Forwarder', function () {
                         Variant: '6',
                         Price: 400,
                         CouponCode: null,
-                        Quantity: 1
-                    }
+                        Quantity: 1,
+                    },
                 ],
                 TransactionId: 123,
                 Affiliation: 'my-affiliation',
                 TotalAmount: 450,
                 TaxAmount: 40,
                 ShippingAmount: 10,
-                CouponCode: null
-            }
+                CouponCode: null,
+            },
         });
 
-        window.googleanalytics.args[0][0].should.equal('tracker-name.ec:addProduct');
+        window.googleanalytics.args[0][0].should.equal(
+            'tracker-name.ec:addProduct'
+        );
         window.googleanalytics.args[0][1].should.have.property('id', '12345');
-        window.googleanalytics.args[0][1].should.have.property('name', 'iPhone 6');
-        window.googleanalytics.args[0][1].should.have.property('category', 'Phones');
-        window.googleanalytics.args[0][1].should.have.property('brand', 'iPhone');
+        window.googleanalytics.args[0][1].should.have.property(
+            'name',
+            'iPhone 6'
+        );
+        window.googleanalytics.args[0][1].should.have.property(
+            'category',
+            'Phones'
+        );
+        window.googleanalytics.args[0][1].should.have.property(
+            'brand',
+            'iPhone'
+        );
         window.googleanalytics.args[0][1].should.have.property('variant', '6');
         window.googleanalytics.args[0][1].should.have.property('price', 400);
         window.googleanalytics.args[0][1].should.have.property('coupon', null);
         window.googleanalytics.args[0][1].should.have.property('quantity', 1);
 
-        window.googleanalytics.args[1][0].should.equal('tracker-name.ec:setAction');
+        window.googleanalytics.args[1][0].should.equal(
+            'tracker-name.ec:setAction'
+        );
         window.googleanalytics.args[1][1].should.equal('purchase');
         window.googleanalytics.args[1][2].should.have.property('id', 123);
-        window.googleanalytics.args[1][2].should.have.property('affiliation', 'my-affiliation');
+        window.googleanalytics.args[1][2].should.have.property(
+            'affiliation',
+            'my-affiliation'
+        );
         window.googleanalytics.args[1][2].should.have.property('revenue', 450);
         window.googleanalytics.args[1][2].should.have.property('tax', 40);
         window.googleanalytics.args[1][2].should.have.property('shipping', 10);
@@ -431,19 +517,23 @@ describe('Google Analytics Forwarder', function () {
                 ProductList: [
                     {
                         Sku: '12345',
-                        Quantity: 1
-                    }
+                        Quantity: 1,
+                    },
                 ],
-                TransactionId: 123
-            }
+                TransactionId: 123,
+            },
         };
         mParticle.forwarder.process(event);
 
-        window.googleanalytics.args[0][0].should.equal('tracker-name.ec:addProduct');
+        window.googleanalytics.args[0][0].should.equal(
+            'tracker-name.ec:addProduct'
+        );
         window.googleanalytics.args[0][1].should.have.property('id', '12345');
         window.googleanalytics.args[0][1].should.have.property('quantity', 1);
 
-        window.googleanalytics.args[1][0].should.equal('tracker-name.ec:setAction');
+        window.googleanalytics.args[1][0].should.equal(
+            'tracker-name.ec:setAction'
+        );
         window.googleanalytics.args[1][1].should.equal('refund');
         window.googleanalytics.args[1][2].should.have.property('id', 123);
 
@@ -454,7 +544,7 @@ describe('Google Analytics Forwarder', function () {
 
         window.googleanalytics.args = [];
 
-        event.CustomFlags = { 'Google.HitType': 'abcdef'};
+        event.CustomFlags = { 'Google.HitType': 'abcdef' };
         mParticle.forwarder.process(event);
         window.googleanalytics.args[2][1].should.equal('abcdef');
 
@@ -469,18 +559,22 @@ describe('Google Analytics Forwarder', function () {
                 ProductList: [
                     {
                         Sku: '12345',
-                        Quantity: 1
-                    }
-                ]
-            }
+                        Quantity: 1,
+                    },
+                ],
+            },
         };
         mParticle.forwarder.process(event);
 
-        window.googleanalytics.args[0][0].should.equal('tracker-name.ec:addProduct');
+        window.googleanalytics.args[0][0].should.equal(
+            'tracker-name.ec:addProduct'
+        );
         window.googleanalytics.args[0][1].should.have.property('id', '12345');
         window.googleanalytics.args[0][1].should.have.property('quantity', 1);
 
-        window.googleanalytics.args[1][0].should.equal('tracker-name.ec:setAction');
+        window.googleanalytics.args[1][0].should.equal(
+            'tracker-name.ec:setAction'
+        );
         window.googleanalytics.args[1][1].should.equal('add');
 
         window.googleanalytics.args[2][0].should.equal('tracker-name.send');
@@ -490,7 +584,7 @@ describe('Google Analytics Forwarder', function () {
 
         window.googleanalytics.args = [];
 
-        event.CustomFlags = { 'Google.HitType': 'abcdef'};
+        event.CustomFlags = { 'Google.HitType': 'abcdef' };
         mParticle.forwarder.process(event);
         window.googleanalytics.args[2][1].should.equal('abcdef');
 
@@ -505,19 +599,23 @@ describe('Google Analytics Forwarder', function () {
                 ProductList: [
                     {
                         Sku: '12345',
-                        Quantity: 1
-                    }
-                ]
-            }
+                        Quantity: 1,
+                    },
+                ],
+            },
         };
 
         mParticle.forwarder.process(event);
 
-        window.googleanalytics.args[0][0].should.equal('tracker-name.ec:addProduct');
+        window.googleanalytics.args[0][0].should.equal(
+            'tracker-name.ec:addProduct'
+        );
         window.googleanalytics.args[0][1].should.have.property('id', '12345');
         window.googleanalytics.args[0][1].should.have.property('quantity', 1);
 
-        window.googleanalytics.args[1][0].should.equal('tracker-name.ec:setAction');
+        window.googleanalytics.args[1][0].should.equal(
+            'tracker-name.ec:setAction'
+        );
         window.googleanalytics.args[1][1].should.equal('remove');
 
         window.googleanalytics.args[2][0].should.equal('tracker-name.send');
@@ -527,14 +625,14 @@ describe('Google Analytics Forwarder', function () {
 
         window.googleanalytics.args = [];
 
-        event.CustomFlags = { 'Google.HitType': 'abcdef'};
+        event.CustomFlags = { 'Google.HitType': 'abcdef' };
         mParticle.forwarder.process(event);
         window.googleanalytics.args[2][1].should.equal('abcdef');
 
         done();
     });
 
-    it('should log checkout', function (done) {
+    it('should log checkout', function(done) {
         var event = {
             EventDataType: MessageType.Commerce,
             ProductAction: {
@@ -542,23 +640,30 @@ describe('Google Analytics Forwarder', function () {
                 ProductList: [
                     {
                         Sku: '12345',
-                        Quantity: 1
-                    }
+                        Quantity: 1,
+                    },
                 ],
                 CheckoutStep: 1,
-                CheckoutOptions: 'Visa'
-            }
+                CheckoutOptions: 'Visa',
+            },
         };
         mParticle.forwarder.process(event);
 
-        window.googleanalytics.args[0][0].should.equal('tracker-name.ec:addProduct');
+        window.googleanalytics.args[0][0].should.equal(
+            'tracker-name.ec:addProduct'
+        );
         window.googleanalytics.args[0][1].should.have.property('id', '12345');
         window.googleanalytics.args[0][1].should.have.property('quantity', 1);
 
-        window.googleanalytics.args[1][0].should.equal('tracker-name.ec:setAction');
+        window.googleanalytics.args[1][0].should.equal(
+            'tracker-name.ec:setAction'
+        );
         window.googleanalytics.args[1][1].should.equal('checkout');
         window.googleanalytics.args[1][2].should.have.property('step', 1);
-        window.googleanalytics.args[1][2].should.have.property('option', 'Visa');
+        window.googleanalytics.args[1][2].should.have.property(
+            'option',
+            'Visa'
+        );
 
         window.googleanalytics.args[2][0].should.equal('tracker-name.send');
         window.googleanalytics.args[2][1].should.equal('event');
@@ -567,14 +672,14 @@ describe('Google Analytics Forwarder', function () {
 
         window.googleanalytics.args = [];
 
-        event.CustomFlags = { 'Google.HitType': 'abcdef'};
+        event.CustomFlags = { 'Google.HitType': 'abcdef' };
         mParticle.forwarder.process(event);
         window.googleanalytics.args[2][1].should.equal('abcdef');
 
         done();
     });
 
-    it('should log product click', function (done) {
+    it('should log product click', function(done) {
         var event = {
             EventDataType: MessageType.Commerce,
             ProductAction: {
@@ -582,18 +687,22 @@ describe('Google Analytics Forwarder', function () {
                 ProductList: [
                     {
                         Sku: '12345',
-                        Quantity: 1
-                    }
-                ]
-            }
+                        Quantity: 1,
+                    },
+                ],
+            },
         };
         mParticle.forwarder.process(event);
 
-        window.googleanalytics.args[0][0].should.equal('tracker-name.ec:addProduct');
+        window.googleanalytics.args[0][0].should.equal(
+            'tracker-name.ec:addProduct'
+        );
         window.googleanalytics.args[0][1].should.have.property('id', '12345');
         window.googleanalytics.args[0][1].should.have.property('quantity', 1);
 
-        window.googleanalytics.args[1][0].should.equal('tracker-name.ec:setAction');
+        window.googleanalytics.args[1][0].should.equal(
+            'tracker-name.ec:setAction'
+        );
         window.googleanalytics.args[1][1].should.equal('click');
 
         window.googleanalytics.args[2][0].should.equal('tracker-name.send');
@@ -603,7 +712,7 @@ describe('Google Analytics Forwarder', function () {
 
         window.googleanalytics.args = [];
 
-        event.CustomFlags = { 'Google.HitType': 'abcdef'};
+        event.CustomFlags = { 'Google.HitType': 'abcdef' };
         mParticle.forwarder.process(event);
         window.googleanalytics.args[2][1].should.equal('abcdef');
 
@@ -618,19 +727,23 @@ describe('Google Analytics Forwarder', function () {
                 ProductList: [
                     {
                         Sku: '12345',
-                        Quantity: 1
-                    }
-                ]
-            }
+                        Quantity: 1,
+                    },
+                ],
+            },
         };
 
         mParticle.forwarder.process(event);
 
-        window.googleanalytics.args[0][0].should.equal('tracker-name.ec:addProduct');
+        window.googleanalytics.args[0][0].should.equal(
+            'tracker-name.ec:addProduct'
+        );
         window.googleanalytics.args[0][1].should.have.property('id', '12345');
         window.googleanalytics.args[0][1].should.have.property('quantity', 1);
 
-        window.googleanalytics.args[1][0].should.equal('tracker-name.ec:setAction');
+        window.googleanalytics.args[1][0].should.equal(
+            'tracker-name.ec:setAction'
+        );
         window.googleanalytics.args[1][1].should.equal('detail');
 
         window.googleanalytics.args[2][0].should.equal('tracker-name.send');
@@ -640,7 +753,7 @@ describe('Google Analytics Forwarder', function () {
 
         window.googleanalytics.args = [];
 
-        event.CustomFlags = { 'Google.HitType': 'abcdef'};
+        event.CustomFlags = { 'Google.HitType': 'abcdef' };
         mParticle.forwarder.process(event);
         window.googleanalytics.args[2][1].should.equal('abcdef');
 
@@ -653,23 +766,36 @@ describe('Google Analytics Forwarder', function () {
             ProductImpressions: [
                 {
                     ProductImpressionList: 'Test',
-                    ProductList: [{
-                        Sku: '12345',
-                        Name: 'iPhone 6',
-                        Category: 'Phones',
-                        Brand: 'iPhone',
-                        Variant: 'S'
-                    }]
-                }
-            ]
+                    ProductList: [
+                        {
+                            Sku: '12345',
+                            Name: 'iPhone 6',
+                            Category: 'Phones',
+                            Brand: 'iPhone',
+                            Variant: 'S',
+                        },
+                    ],
+                },
+            ],
         };
         mParticle.forwarder.process(event);
 
-        window.googleanalytics.args[0][0].should.equal('tracker-name.ec:addImpression');
+        window.googleanalytics.args[0][0].should.equal(
+            'tracker-name.ec:addImpression'
+        );
         window.googleanalytics.args[0][1].should.have.property('id', '12345');
-        window.googleanalytics.args[0][1].should.have.property('name', 'iPhone 6');
-        window.googleanalytics.args[0][1].should.have.property('category', 'Phones');
-        window.googleanalytics.args[0][1].should.have.property('brand', 'iPhone');
+        window.googleanalytics.args[0][1].should.have.property(
+            'name',
+            'iPhone 6'
+        );
+        window.googleanalytics.args[0][1].should.have.property(
+            'category',
+            'Phones'
+        );
+        window.googleanalytics.args[0][1].should.have.property(
+            'brand',
+            'iPhone'
+        );
         window.googleanalytics.args[0][1].should.have.property('variant', 'S');
 
         window.googleanalytics.args[1][0].should.equal('tracker-name.send');
@@ -679,7 +805,7 @@ describe('Google Analytics Forwarder', function () {
 
         window.googleanalytics.args = [];
 
-        event.CustomFlags = {'Google.HitType': 'abcdef'};
+        event.CustomFlags = { 'Google.HitType': 'abcdef' };
         mParticle.forwarder.process(event);
         window.googleanalytics.args[1][1].should.equal('abcdef');
 
@@ -687,11 +813,16 @@ describe('Google Analytics Forwarder', function () {
     });
 
     it('it should set user identity', function(done) {
-        mParticle.forwarder.setUserIdentity('tbreffni@mparticle.com', IdentityType.CustomerId);
+        mParticle.forwarder.setUserIdentity(
+            'tbreffni@mparticle.com',
+            IdentityType.CustomerId
+        );
 
         window.googleanalytics.args[0][0].should.equal('tracker-name.set');
         window.googleanalytics.args[0][1].should.equal('userId');
-        window.googleanalytics.args[0][2].should.equal(mParticle.generateHash('tbreffni@mparticle.com'));
+        window.googleanalytics.args[0][2].should.equal(
+            mParticle.generateHash('tbreffni@mparticle.com')
+        );
 
         done();
     });
@@ -706,17 +837,25 @@ describe('Google Analytics Forwarder', function () {
                         Id: 12345,
                         Creative: 'my creative',
                         Name: 'Test promotion',
-                        Position: 3
-                    }
-                ]
-            }
+                        Position: 3,
+                    },
+                ],
+            },
         };
         mParticle.forwarder.process(event);
 
-        window.googleanalytics.args[0][0].should.equal('tracker-name.ec:addPromo');
+        window.googleanalytics.args[0][0].should.equal(
+            'tracker-name.ec:addPromo'
+        );
         window.googleanalytics.args[0][1].should.have.property('id', 12345);
-        window.googleanalytics.args[0][1].should.have.property('name', 'Test promotion');
-        window.googleanalytics.args[0][1].should.have.property('creative', 'my creative');
+        window.googleanalytics.args[0][1].should.have.property(
+            'name',
+            'Test promotion'
+        );
+        window.googleanalytics.args[0][1].should.have.property(
+            'creative',
+            'my creative'
+        );
         window.googleanalytics.args[0][1].should.have.property('position', 3);
 
         window.googleanalytics.args[1][0].should.equal('tracker-name.send');
@@ -726,7 +865,7 @@ describe('Google Analytics Forwarder', function () {
 
         window.googleanalytics.args = [];
 
-        event.CustomFlags = {'Google.HitType': 'abcdef'};
+        event.CustomFlags = { 'Google.HitType': 'abcdef' };
         mParticle.forwarder.process(event);
         window.googleanalytics.args[1][1].should.equal('abcdef');
 
@@ -743,19 +882,29 @@ describe('Google Analytics Forwarder', function () {
                         Id: 12345,
                         Creative: 'my creative',
                         Name: 'Test promotion',
-                        Position: 3
-                    }
-                ]
-            }
+                        Position: 3,
+                    },
+                ],
+            },
         });
 
-        window.googleanalytics.args[0][0].should.equal('tracker-name.ec:addPromo');
+        window.googleanalytics.args[0][0].should.equal(
+            'tracker-name.ec:addPromo'
+        );
         window.googleanalytics.args[0][1].should.have.property('id', 12345);
-        window.googleanalytics.args[0][1].should.have.property('name', 'Test promotion');
-        window.googleanalytics.args[0][1].should.have.property('creative', 'my creative');
+        window.googleanalytics.args[0][1].should.have.property(
+            'name',
+            'Test promotion'
+        );
+        window.googleanalytics.args[0][1].should.have.property(
+            'creative',
+            'my creative'
+        );
         window.googleanalytics.args[0][1].should.have.property('position', 3);
 
-        window.googleanalytics.args[1][0].should.equal('tracker-name.ec:setAction');
+        window.googleanalytics.args[1][0].should.equal(
+            'tracker-name.ec:setAction'
+        );
         window.googleanalytics.args[1][1].should.equal('promo_click');
 
         window.googleanalytics.args[2][0].should.equal('tracker-name.send');


### PR DESCRIPTION
Previously, this integration did not allow for duplicate mappings because we would create a mapping object with keys of `dimension number`, and value of the `attribute`. 

For example, let's say a customer maps `Screen Time` to `dimension 1`, `deviceType` to `dimension 2` and `screentime` to `dimension 1`. In this example, with the current code, the mapping object starts as 
```
{
dimension1: 'Screen Time',
dimension2: 'deviceType'
}
```

then turns into 

```
{
dimension1: 'screentime',
dimension2: 'deviceType'
}
```
Our mapping is incorrect because the key is the dimension, which in our UI can be mapped to several times.  Instead, the mapping object should be keyed off of the `attribute` and a value of the `dimension`. Events with a `Screen Time` attribute do not get sent properly

In the changed code, the above mapping is now:
```
{
 'Screen Time: 'dimension1',
 'deviceType': 'dimension2',
 'screentime': 'dimension1'
}
```

This allows for all events to be mapped, and not just the last attribute that was mapped to the same dimension. Events with a `Screen Time` attribute  now send properly.