### PR TITLE
Update GoogleAnalyticsEventForwarder.js

### DIFF
--- a/GoogleAnalyticsEventForwarder.js
+++ b/GoogleAnalyticsEventForwarder.js
@@ -31,6 +31,7 @@ var mpGoogleAnalyticsKit = (function (exports) {
             NON_INTERACTION_FLAG = 'Google.NonInteraction',
             CATEGORY = 'Google.Category',
             LABEL = 'Google.Label',
+            TITLE = 'Google.Title';
             PAGE = 'Google.Page',
             VALUE = 'Google.Value',
             HITTYPE = 'Google.HitType';
@@ -333,6 +334,9 @@ var mpGoogleAnalyticsKit = (function (exports) {
                 else {
                     if (event.CustomFlags && event.CustomFlags[PAGE]) {
                         ga(createCmd('set'), 'page', event.CustomFlags[PAGE]);
+                    }
+                    if (event.CustomFlags && event.CustomFlags[TITLE]){
+                        ga(createCmd('set'), 'page', event.CustomFlags[TITLE]);
                     }
                     ga(createCmd('send'), customFlags && customFlags[HITTYPE] ? customFlags[HITTYPE] : 'pageview', outputDimensionsAndMetrics);
                 }

--- a/GoogleAnalyticsEventForwarder.js
+++ b/GoogleAnalyticsEventForwarder.js
@@ -336,7 +336,7 @@ var mpGoogleAnalyticsKit = (function (exports) {
                         ga(createCmd('set'), 'page', event.CustomFlags[PAGE]);
                     }
                     if (event.CustomFlags && event.CustomFlags[TITLE]){
-                        ga(createCmd('set'), 'page', event.CustomFlags[TITLE]);
+                        ga(createCmd('set'), 'title', event.CustomFlags[TITLE]);
                     }
                     ga(createCmd('send'), customFlags && customFlags[HITTYPE] ? customFlags[HITTYPE] : 'pageview', outputDimensionsAndMetrics);
                 }

--- a/dist/GoogleAnalyticsEventForwarder.common.js
+++ b/dist/GoogleAnalyticsEventForwarder.common.js
@@ -32,6 +32,7 @@ Object.defineProperty(exports, '__esModule', { value: true });
         NON_INTERACTION_FLAG = 'Google.NonInteraction',
         CATEGORY = 'Google.Category',
         LABEL = 'Google.Label',
+        TITLE = 'Google.Title';
         PAGE = 'Google.Page',
         VALUE = 'Google.Value',
         HITTYPE = 'Google.HitType';
@@ -334,6 +335,9 @@ Object.defineProperty(exports, '__esModule', { value: true });
             else {
                 if (event.CustomFlags && event.CustomFlags[PAGE]) {
                     ga(createCmd('set'), 'page', event.CustomFlags[PAGE]);
+                }
+                if (event.CustomFlags && event.CustomFlags[TITLE]){
+                    ga(createCmd('set'), 'page', event.CustomFlags[TITLE]);
                 }
                 ga(createCmd('send'), customFlags && customFlags[HITTYPE] ? customFlags[HITTYPE] : 'pageview', outputDimensionsAndMetrics);
             }

--- a/dist/GoogleAnalyticsEventForwarder.common.js
+++ b/dist/GoogleAnalyticsEventForwarder.common.js
@@ -337,7 +337,7 @@ Object.defineProperty(exports, '__esModule', { value: true });
                     ga(createCmd('set'), 'page', event.CustomFlags[PAGE]);
                 }
                 if (event.CustomFlags && event.CustomFlags[TITLE]){
-                    ga(createCmd('set'), 'page', event.CustomFlags[TITLE]);
+                    ga(createCmd('set'), 'title', event.CustomFlags[TITLE]);
                 }
                 ga(createCmd('send'), customFlags && customFlags[HITTYPE] ? customFlags[HITTYPE] : 'pageview', outputDimensionsAndMetrics);
             }

--- a/dist/GoogleAnalyticsEventForwarder.iife.js
+++ b/dist/GoogleAnalyticsEventForwarder.iife.js
@@ -31,6 +31,7 @@ var mpGoogleAnalyticsKit = (function (exports) {
             NON_INTERACTION_FLAG = 'Google.NonInteraction',
             CATEGORY = 'Google.Category',
             LABEL = 'Google.Label',
+            TITLE = 'Google.Title';
             PAGE = 'Google.Page',
             VALUE = 'Google.Value',
             HITTYPE = 'Google.HitType';
@@ -333,6 +334,9 @@ var mpGoogleAnalyticsKit = (function (exports) {
                 else {
                     if (event.CustomFlags && event.CustomFlags[PAGE]) {
                         ga(createCmd('set'), 'page', event.CustomFlags[PAGE]);
+                    }
+                    if (event.CustomFlags && event.CustomFlags[TITLE]){
+                        ga(createCmd('set'), 'page', event.CustomFlags[TITLE]);
                     }
                     ga(createCmd('send'), customFlags && customFlags[HITTYPE] ? customFlags[HITTYPE] : 'pageview', outputDimensionsAndMetrics);
                 }

--- a/dist/GoogleAnalyticsEventForwarder.iife.js
+++ b/dist/GoogleAnalyticsEventForwarder.iife.js
@@ -336,7 +336,7 @@ var mpGoogleAnalyticsKit = (function (exports) {
                         ga(createCmd('set'), 'page', event.CustomFlags[PAGE]);
                     }
                     if (event.CustomFlags && event.CustomFlags[TITLE]){
-                        ga(createCmd('set'), 'page', event.CustomFlags[TITLE]);
+                        ga(createCmd('set'), 'title', event.CustomFlags[TITLE]);
                     }
                     ga(createCmd('send'), customFlags && customFlags[HITTYPE] ? customFlags[HITTYPE] : 'pageview', outputDimensionsAndMetrics);
                 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -25,19 +25,20 @@
             }
         },
         "@babel/runtime": {
-            "version": "7.7.2",
-            "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.7.2.tgz",
-            "integrity": "sha512-JONRbXbTXc9WQE2mAZd1p0Z3DZ/6vaQIkgYMSTP3KjRCyd7rCZCcfhCyX+YjwcKxcZ82UrxbRD358bpExNgrjw==",
+            "version": "7.7.7",
+            "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.7.7.tgz",
+            "integrity": "sha512-uCnC2JEVAu8AKB5do1WRIsvrdJ0flYx/A/9f/6chdacnEZ7LmavjdsDXr5ksYBegxtuTPR5Va9/+13QF/kFkCA==",
             "requires": {
                 "regenerator-runtime": "^0.13.2"
             }
         },
         "@mparticle/web-sdk": {
-            "version": "2.9.13-rc.1",
-            "resolved": "https://registry.npmjs.org/@mparticle/web-sdk/-/web-sdk-2.9.13-rc.1.tgz",
-            "integrity": "sha512-C7FYXT6jfKYn0R6uD3oLoR4seqainhgTtRanhULQkyWS0+gmZ+rILwIX+K3+GLMWUe63+0jIzPZPnX9e4OiwfA==",
+            "version": "2.10.1",
+            "resolved": "https://registry.npmjs.org/@mparticle/web-sdk/-/web-sdk-2.10.1.tgz",
+            "integrity": "sha512-KJqHzkJJ2Cnb+r+VkpO//2SkEsFBJGQLKvb4sccpOaQ3TUQ6Q9HK0r3QCe48fst8AhmZHUUT2nJzqdtdcMxk5w==",
             "requires": {
-                "@babel/runtime": "^7.6.0"
+                "@babel/runtime": "^7.6.0",
+                "slugify": "^1.3.6"
             }
         },
         "@types/estree": {
@@ -1184,6 +1185,11 @@
                 "astral-regex": "^1.0.0",
                 "is-fullwidth-code-point": "^2.0.0"
             }
+        },
+        "slugify": {
+            "version": "1.3.6",
+            "resolved": "https://registry.npmjs.org/slugify/-/slugify-1.3.6.tgz",
+            "integrity": "sha512-wA9XS475ZmGNlEnYYLPReSfuz/c3VQsEMoU43mi6OnKMCdbnFXd4/Yg7J0lBv8jkPolacMpOrWEaoYxuE1+hoQ=="
         },
         "sourcemap-codec": {
             "version": "1.4.4",

--- a/src/GoogleAnalyticsEventForwarder.js
+++ b/src/GoogleAnalyticsEventForwarder.js
@@ -30,6 +30,7 @@
         NON_INTERACTION_FLAG = 'Google.NonInteraction',
         CATEGORY = 'Google.Category',
         LABEL = 'Google.Label',
+        TITLE = 'Google.Title'
         PAGE = 'Google.Page',
         VALUE = 'Google.Value',
         HITTYPE = 'Google.HitType';
@@ -334,6 +335,9 @@
             else {
                 if (event.CustomFlags && event.CustomFlags[PAGE]) {
                     ga(createCmd('set'), 'page', event.CustomFlags[PAGE]);
+                }
+                if (event.CustomFlags && event.CustomFlags[TITLE]){
+                    ga(createCmd('set'), 'page', event.CustomFlags[TITLE]);
                 }
                 ga(createCmd('send'), customFlags && customFlags[HITTYPE] ? customFlags[HITTYPE] : 'pageview', outputDimensionsAndMetrics);
             }

--- a/src/GoogleAnalyticsEventForwarder.js
+++ b/src/GoogleAnalyticsEventForwarder.js
@@ -337,7 +337,7 @@
                     ga(createCmd('set'), 'page', event.CustomFlags[PAGE]);
                 }
                 if (event.CustomFlags && event.CustomFlags[TITLE]){
-                    ga(createCmd('set'), 'page', event.CustomFlags[TITLE]);
+                    ga(createCmd('set'), 'title', event.CustomFlags[TITLE]);
                 }
                 ga(createCmd('send'), customFlags && customFlags[HITTYPE] ? customFlags[HITTYPE] : 'pageview', outputDimensionsAndMetrics);
             }

--- a/test/tests.js
+++ b/test/tests.js
@@ -239,7 +239,6 @@ describe('Google Analytics Forwarder', function() {
         done();
     });
 
-
     it('should change page name for custom flag based on Google.Title', function(done) {
         mParticle.forwarder.process({
             EventDataType: MessageType.PageView,
@@ -253,7 +252,7 @@ describe('Google Analytics Forwarder', function() {
         });
 
         window.googleanalytics.args[0][0].should.equal('tracker-name.set');
-        window.googleanalytics.args[0][1].should.equal('page');
+        window.googleanalytics.args[0][1].should.equal('title');
         window.googleanalytics.args[0][2].should.equal('foo title');
 
         done();
@@ -269,7 +268,6 @@ describe('Google Analytics Forwarder', function() {
             CustomFlags: {
                 'Google.Page': 'foo page',
                 'Google.Title': 'foo title',
-
             },
         });
 
@@ -278,7 +276,7 @@ describe('Google Analytics Forwarder', function() {
         window.googleanalytics.args[0][2].should.equal('foo page');
 
         window.googleanalytics.args[1][0].should.equal('tracker-name.set');
-        window.googleanalytics.args[1][1].should.equal('page');
+        window.googleanalytics.args[1][1].should.equal('title');
         window.googleanalytics.args[1][2].should.equal('foo title');
 
         done();

--- a/test/tests.js
+++ b/test/tests.js
@@ -220,7 +220,7 @@ describe('Google Analytics Forwarder', function() {
         done();
     });
 
-    it('should change page name for custom flag', function(done) {
+    it('should change page name for custom flag based on Google.Page', function(done) {
         mParticle.forwarder.process({
             EventDataType: MessageType.PageView,
             EventName: 'Test Page Event',
@@ -235,6 +235,51 @@ describe('Google Analytics Forwarder', function() {
         window.googleanalytics.args[0][0].should.equal('tracker-name.set');
         window.googleanalytics.args[0][1].should.equal('page');
         window.googleanalytics.args[0][2].should.equal('foo page');
+
+        done();
+    });
+
+
+    it('should change page name for custom flag based on Google.Title', function(done) {
+        mParticle.forwarder.process({
+            EventDataType: MessageType.PageView,
+            EventName: 'Test Page Event',
+            EventAttributes: {
+                anything: 'foo',
+            },
+            CustomFlags: {
+                'Google.Title': 'foo title',
+            },
+        });
+
+        window.googleanalytics.args[0][0].should.equal('tracker-name.set');
+        window.googleanalytics.args[0][1].should.equal('page');
+        window.googleanalytics.args[0][2].should.equal('foo title');
+
+        done();
+    });
+
+    it('should change page name for custom flag based on both Google.Page and Google.Title', function(done) {
+        mParticle.forwarder.process({
+            EventDataType: MessageType.PageView,
+            EventName: 'Test Page Event',
+            EventAttributes: {
+                anything: 'foo',
+            },
+            CustomFlags: {
+                'Google.Page': 'foo page',
+                'Google.Title': 'foo title',
+
+            },
+        });
+
+        window.googleanalytics.args[0][0].should.equal('tracker-name.set');
+        window.googleanalytics.args[0][1].should.equal('page');
+        window.googleanalytics.args[0][2].should.equal('foo page');
+
+        window.googleanalytics.args[1][0].should.equal('tracker-name.set');
+        window.googleanalytics.args[1][1].should.equal('page');
+        window.googleanalytics.args[1][2].should.equal('foo title');
 
         done();
     });


### PR DESCRIPTION
We noticed that to log page views for single-page web applications Google.Title was not being passed. It looked like the current logPageView only checked for Google.Page.

I added TITLE var and logic to check if Google.Title is present - based off how we were checking Google.Page in logPageView