### PR TITLE
Bugfix - Allow an attribute to be mapped to multiple dimensions

### DIFF
--- a/GoogleAnalyticsEventForwarder.js
+++ b/GoogleAnalyticsEventForwarder.js
@@ -17,7 +17,7 @@ var mpGoogleAnalyticsKit = (function (exports) {
 
         var name = 'GoogleAnalyticsEventForwarder',
             moduleId = 6,
-            version = '2.0.2',
+            version = '2.0.4',
             MessageType = {
                 SessionStart: 1,
                 SessionEnd: 2,
@@ -90,7 +90,11 @@ var mpGoogleAnalyticsKit = (function (exports) {
                 for (var customDimension in mapLevel.customDimensions) {
                     for (attrName in attributes) {
                         if (customDimension === attrName) {
-                            targetDimensionsAndMetrics[mapLevel.customDimensions[customDimension]] = attributes[attrName];
+                            mapLevel.customDimensions[customDimension].forEach(function(cd) {
+                                if (!targetDimensionsAndMetrics[cd]) {
+                                    targetDimensionsAndMetrics[cd] = attributes[attrName];
+                                }
+                            });
                         }
                     }
                 }
@@ -98,7 +102,11 @@ var mpGoogleAnalyticsKit = (function (exports) {
                 for (var customMetric in mapLevel.customMetrics) {
                     for (attrName in attributes) {
                         if (customMetric === attrName) {
-                            targetDimensionsAndMetrics[mapLevel.customMetrics[customMetric]] = attributes[attrName];
+                            mapLevel.customMetrics[customMetric].forEach(function(cm) {
+                                if (!targetDimensionsAndMetrics[cm]) {
+                                    targetDimensionsAndMetrics[cm] = attributes[attrName];
+                                }
+                            });
                         }
                     }
                 }
@@ -469,15 +477,16 @@ var mpGoogleAnalyticsKit = (function (exports) {
                         if (forwarderSettings.useSecure == 'True') {
                             ga(createCmd('set'), 'forceSSL', true);
                         }
+
                         if (forwarderSettings.customDimensions) {
                             var customDimensions = JSON.parse(forwarderSettings.customDimensions.replace(/&quot;/g, '\"'));
                             customDimensions.forEach(function(dimension) {
                                 if (dimension.maptype === 'EventAttributeClass.Name') {
-                                    eventLevelMap['customDimensions'][dimension.map] = formatDimensionOrMetric(dimension.value);
+                                    addTypeToMapping(eventLevelMap, 'customDimensions', dimension);
                                 } else if (dimension.maptype === 'UserAttributeClass.Name') {
-                                    userLevelMap['customDimensions'][dimension.map] = formatDimensionOrMetric(dimension.value);
+                                    addTypeToMapping(userLevelMap, 'customDimensions', dimension);
                                 } else if (dimension.maptype === 'ProductAttributeSelector.Name') {
-                                    productLevelMap['customDimensions'][dimension.map] = formatDimensionOrMetric(dimension.value);
+                                    addTypeToMapping(productLevelMap, 'customDimensions', dimension);
                                 }
                             });
                         }
@@ -486,11 +495,11 @@ var mpGoogleAnalyticsKit = (function (exports) {
                             var customMetrics = JSON.parse(forwarderSettings.customMetrics.replace(/&quot;/g, '\"'));
                             customMetrics.forEach(function(metric) {
                                 if (metric.maptype === 'EventAttributeClass.Name') {
-                                    eventLevelMap['customMetrics'][metric.map] = formatDimensionOrMetric(metric.value);
+                                    addTypeToMapping(eventLevelMap, 'customMetrics', metric);
                                 } else if (metric.maptype === 'UserAttributeClass.Name') {
-                                    userLevelMap['customMetrics'][metric.map] = formatDimensionOrMetric(metric.value);
+                                    addTypeToMapping(userLevelMap, 'customMetrics', metric);
                                 } else if (metric.maptype === 'ProductAttributeSelector.Name') {
-                                    productLevelMap['customMetrics'][metric.map] = formatDimensionOrMetric(metric.value);
+                                    addTypeToMapping(productLevelMap, 'customMetrics', metric);
                                 }
                             });
                         }
@@ -501,6 +510,18 @@ var mpGoogleAnalyticsKit = (function (exports) {
                 }
                 catch (e) {
                     return 'Failed to initialize: ' + name;
+                }
+            }
+
+            function addTypeToMapping(map, type, mapVal) {
+                var formattedMapVal = formatDimensionOrMetric(mapVal.value);
+                if (!map[type][mapVal.map]) {
+                    map[type][mapVal.map] = [formattedMapVal];
+                    return;
+                }
+
+                if (!map[type][mapVal.map].indexOf(mapVal.value) >= 0) {
+                    map[type][mapVal.map].push(formattedMapVal);
                 }
             }
 

--- a/dist/GoogleAnalyticsEventForwarder.common.js
+++ b/dist/GoogleAnalyticsEventForwarder.common.js
@@ -18,7 +18,7 @@ Object.defineProperty(exports, '__esModule', { value: true });
 
     var name = 'GoogleAnalyticsEventForwarder',
         moduleId = 6,
-        version = '2.0.2',
+        version = '2.0.4',
         MessageType = {
             SessionStart: 1,
             SessionEnd: 2,
@@ -91,7 +91,11 @@ Object.defineProperty(exports, '__esModule', { value: true });
             for (var customDimension in mapLevel.customDimensions) {
                 for (attrName in attributes) {
                     if (customDimension === attrName) {
-                        targetDimensionsAndMetrics[mapLevel.customDimensions[customDimension]] = attributes[attrName];
+                        mapLevel.customDimensions[customDimension].forEach(function(cd) {
+                            if (!targetDimensionsAndMetrics[cd]) {
+                                targetDimensionsAndMetrics[cd] = attributes[attrName];
+                            }
+                        });
                     }
                 }
             }
@@ -99,7 +103,11 @@ Object.defineProperty(exports, '__esModule', { value: true });
             for (var customMetric in mapLevel.customMetrics) {
                 for (attrName in attributes) {
                     if (customMetric === attrName) {
-                        targetDimensionsAndMetrics[mapLevel.customMetrics[customMetric]] = attributes[attrName];
+                        mapLevel.customMetrics[customMetric].forEach(function(cm) {
+                            if (!targetDimensionsAndMetrics[cm]) {
+                                targetDimensionsAndMetrics[cm] = attributes[attrName];
+                            }
+                        });
                     }
                 }
             }
@@ -470,15 +478,16 @@ Object.defineProperty(exports, '__esModule', { value: true });
                     if (forwarderSettings.useSecure == 'True') {
                         ga(createCmd('set'), 'forceSSL', true);
                     }
+
                     if (forwarderSettings.customDimensions) {
                         var customDimensions = JSON.parse(forwarderSettings.customDimensions.replace(/&quot;/g, '\"'));
                         customDimensions.forEach(function(dimension) {
                             if (dimension.maptype === 'EventAttributeClass.Name') {
-                                eventLevelMap['customDimensions'][dimension.map] = formatDimensionOrMetric(dimension.value);
+                                addTypeToMapping(eventLevelMap, 'customDimensions', dimension);
                             } else if (dimension.maptype === 'UserAttributeClass.Name') {
-                                userLevelMap['customDimensions'][dimension.map] = formatDimensionOrMetric(dimension.value);
+                                addTypeToMapping(userLevelMap, 'customDimensions', dimension);
                             } else if (dimension.maptype === 'ProductAttributeSelector.Name') {
-                                productLevelMap['customDimensions'][dimension.map] = formatDimensionOrMetric(dimension.value);
+                                addTypeToMapping(productLevelMap, 'customDimensions', dimension);
                             }
                         });
                     }
@@ -487,11 +496,11 @@ Object.defineProperty(exports, '__esModule', { value: true });
                         var customMetrics = JSON.parse(forwarderSettings.customMetrics.replace(/&quot;/g, '\"'));
                         customMetrics.forEach(function(metric) {
                             if (metric.maptype === 'EventAttributeClass.Name') {
-                                eventLevelMap['customMetrics'][metric.map] = formatDimensionOrMetric(metric.value);
+                                addTypeToMapping(eventLevelMap, 'customMetrics', metric);
                             } else if (metric.maptype === 'UserAttributeClass.Name') {
-                                userLevelMap['customMetrics'][metric.map] = formatDimensionOrMetric(metric.value);
+                                addTypeToMapping(userLevelMap, 'customMetrics', metric);
                             } else if (metric.maptype === 'ProductAttributeSelector.Name') {
-                                productLevelMap['customMetrics'][metric.map] = formatDimensionOrMetric(metric.value);
+                                addTypeToMapping(productLevelMap, 'customMetrics', metric);
                             }
                         });
                     }
@@ -502,6 +511,18 @@ Object.defineProperty(exports, '__esModule', { value: true });
             }
             catch (e) {
                 return 'Failed to initialize: ' + name;
+            }
+        }
+
+        function addTypeToMapping(map, type, mapVal) {
+            var formattedMapVal = formatDimensionOrMetric(mapVal.value);
+            if (!map[type][mapVal.map]) {
+                map[type][mapVal.map] = [formattedMapVal];
+                return;
+            }
+
+            if (!map[type][mapVal.map].indexOf(mapVal.value) >= 0) {
+                map[type][mapVal.map].push(formattedMapVal);
             }
         }
 

--- a/dist/GoogleAnalyticsEventForwarder.iife.js
+++ b/dist/GoogleAnalyticsEventForwarder.iife.js
@@ -17,7 +17,7 @@ var mpGoogleAnalyticsKit = (function (exports) {
 
         var name = 'GoogleAnalyticsEventForwarder',
             moduleId = 6,
-            version = '2.0.2',
+            version = '2.0.4',
             MessageType = {
                 SessionStart: 1,
                 SessionEnd: 2,
@@ -90,7 +90,11 @@ var mpGoogleAnalyticsKit = (function (exports) {
                 for (var customDimension in mapLevel.customDimensions) {
                     for (attrName in attributes) {
                         if (customDimension === attrName) {
-                            targetDimensionsAndMetrics[mapLevel.customDimensions[customDimension]] = attributes[attrName];
+                            mapLevel.customDimensions[customDimension].forEach(function(cd) {
+                                if (!targetDimensionsAndMetrics[cd]) {
+                                    targetDimensionsAndMetrics[cd] = attributes[attrName];
+                                }
+                            });
                         }
                     }
                 }
@@ -98,7 +102,11 @@ var mpGoogleAnalyticsKit = (function (exports) {
                 for (var customMetric in mapLevel.customMetrics) {
                     for (attrName in attributes) {
                         if (customMetric === attrName) {
-                            targetDimensionsAndMetrics[mapLevel.customMetrics[customMetric]] = attributes[attrName];
+                            mapLevel.customMetrics[customMetric].forEach(function(cm) {
+                                if (!targetDimensionsAndMetrics[cm]) {
+                                    targetDimensionsAndMetrics[cm] = attributes[attrName];
+                                }
+                            });
                         }
                     }
                 }
@@ -469,15 +477,16 @@ var mpGoogleAnalyticsKit = (function (exports) {
                         if (forwarderSettings.useSecure == 'True') {
                             ga(createCmd('set'), 'forceSSL', true);
                         }
+
                         if (forwarderSettings.customDimensions) {
                             var customDimensions = JSON.parse(forwarderSettings.customDimensions.replace(/&quot;/g, '\"'));
                             customDimensions.forEach(function(dimension) {
                                 if (dimension.maptype === 'EventAttributeClass.Name') {
-                                    eventLevelMap['customDimensions'][dimension.map] = formatDimensionOrMetric(dimension.value);
+                                    addTypeToMapping(eventLevelMap, 'customDimensions', dimension);
                                 } else if (dimension.maptype === 'UserAttributeClass.Name') {
-                                    userLevelMap['customDimensions'][dimension.map] = formatDimensionOrMetric(dimension.value);
+                                    addTypeToMapping(userLevelMap, 'customDimensions', dimension);
                                 } else if (dimension.maptype === 'ProductAttributeSelector.Name') {
-                                    productLevelMap['customDimensions'][dimension.map] = formatDimensionOrMetric(dimension.value);
+                                    addTypeToMapping(productLevelMap, 'customDimensions', dimension);
                                 }
                             });
                         }
@@ -486,11 +495,11 @@ var mpGoogleAnalyticsKit = (function (exports) {
                             var customMetrics = JSON.parse(forwarderSettings.customMetrics.replace(/&quot;/g, '\"'));
                             customMetrics.forEach(function(metric) {
                                 if (metric.maptype === 'EventAttributeClass.Name') {
-                                    eventLevelMap['customMetrics'][metric.map] = formatDimensionOrMetric(metric.value);
+                                    addTypeToMapping(eventLevelMap, 'customMetrics', metric);
                                 } else if (metric.maptype === 'UserAttributeClass.Name') {
-                                    userLevelMap['customMetrics'][metric.map] = formatDimensionOrMetric(metric.value);
+                                    addTypeToMapping(userLevelMap, 'customMetrics', metric);
                                 } else if (metric.maptype === 'ProductAttributeSelector.Name') {
-                                    productLevelMap['customMetrics'][metric.map] = formatDimensionOrMetric(metric.value);
+                                    addTypeToMapping(productLevelMap, 'customMetrics', metric);
                                 }
                             });
                         }
@@ -501,6 +510,18 @@ var mpGoogleAnalyticsKit = (function (exports) {
                 }
                 catch (e) {
                     return 'Failed to initialize: ' + name;
+                }
+            }
+
+            function addTypeToMapping(map, type, mapVal) {
+                var formattedMapVal = formatDimensionOrMetric(mapVal.value);
+                if (!map[type][mapVal.map]) {
+                    map[type][mapVal.map] = [formattedMapVal];
+                    return;
+                }
+
+                if (!map[type][mapVal.map].indexOf(mapVal.value) >= 0) {
+                    map[type][mapVal.map].push(formattedMapVal);
                 }
             }
 

--- a/src/GoogleAnalyticsEventForwarder.js
+++ b/src/GoogleAnalyticsEventForwarder.js
@@ -16,7 +16,7 @@
 
     var name = 'GoogleAnalyticsEventForwarder',
         moduleId = 6,
-        version = '2.0.3',
+        version = '2.0.4',
         MessageType = {
             SessionStart: 1,
             SessionEnd: 2,
@@ -503,7 +503,7 @@
                     console.log(userLevelMap)
                     console.log(eventLevelMap)
                     console.log(productLevelMap)
-                    debugger;
+
                     if (forwarderSettings.customMetrics) {
                         var customMetrics = JSON.parse(forwarderSettings.customMetrics.replace(/&quot;/g, '\"'));
                         customMetrics.forEach(function(metric) {

--- a/src/GoogleAnalyticsEventForwarder.js
+++ b/src/GoogleAnalyticsEventForwarder.js
@@ -90,10 +90,9 @@
                 for (attrName in attributes) {
                     if (customDimension === attrName) {
                         mapLevel.customDimensions[customDimension].forEach(function(cd) {
-                            if (targetDimensionsAndMetrics[cd]) {
-                                console.warn(cd + ' being overwritten. Double check your mappings and/or code, as a particular dimension should not be used more than once.')
+                            if (!targetDimensionsAndMetrics[cd]) {
+                                targetDimensionsAndMetrics[cd] = attributes[attrName];
                             }
-                            targetDimensionsAndMetrics[cd] = attributes[attrName];
                         })
                     }
                 }
@@ -103,10 +102,9 @@
                 for (attrName in attributes) {
                     if (customMetric === attrName) {
                         mapLevel.customMetrics[customMetric].forEach(function(cm) {
-                            if (targetDimensionsAndMetrics[cm]) {
-                                console.warn(cm + ' being overwritten. Double check your mappings and/or code, as a particular metric should not be used more than once.')
+                            if (!targetDimensionsAndMetrics[cm]) {
+                                targetDimensionsAndMetrics[cm] = attributes[attrName];
                             }
-                            targetDimensionsAndMetrics[cm] = attributes[attrName];
                         })
                     }
                 }
@@ -483,54 +481,26 @@
 
                     if (forwarderSettings.customDimensions) {
                         var customDimensions = JSON.parse(forwarderSettings.customDimensions.replace(/&quot;/g, '\"'));
-                        customDimensions.forEach(function(dimension, i) {
+                        customDimensions.forEach(function(dimension) {
                             if (dimension.maptype === 'EventAttributeClass.Name') {
                                 addTypeToMapping(eventLevelMap, 'customDimensions', dimension);
-
-                                
-                                
-                                
-                                // eventLevelMap['customDimensions'][dimension.map] = formatDimensionOrMetric(dimension.value);
                             } else if (dimension.maptype === 'UserAttributeClass.Name') {
                                 addTypeToMapping(userLevelMap, 'customDimensions', dimension);
-                                // userLevelMap['customDimensions'][dimension.map] = formatDimensionOrMetric(dimension.value);
                             } else if (dimension.maptype === 'ProductAttributeSelector.Name') {
                                 addTypeToMapping(productLevelMap, 'customDimensions', dimension);
-                                // productLevelMap['customDimensions'][dimension.map] = formatDimensionOrMetric(dimension.value);
                             }
                         });
                     }
-                    console.log(userLevelMap)
-                    console.log(eventLevelMap)
-                    console.log(productLevelMap)
 
                     if (forwarderSettings.customMetrics) {
                         var customMetrics = JSON.parse(forwarderSettings.customMetrics.replace(/&quot;/g, '\"'));
                         customMetrics.forEach(function(metric) {
                             if (metric.maptype === 'EventAttributeClass.Name') {
                                 addTypeToMapping(eventLevelMap, 'customMetrics', metric);
-
-                                // if (eventLevelMap['customMetrics'][metric.map]) {
-                                //     eventLevelMap['customMetrics'][metric.map].push(formatDimensionOrMetric(metric.value));
-                                // } else {
-                                //     eventLevelMap['customMetrics'][metric.map] = [formatDimensionOrMetric(metric.value)];
-                                // }
                             } else if (metric.maptype === 'UserAttributeClass.Name') {
                                 addTypeToMapping(userLevelMap, 'customMetrics', metric);
-
-                                // if (userLevelMap['customMetrics'][metric.map]) {
-                                //     userLevelMap['customMetrics'][metric.map].push(formatDimensionOrMetric(metric.value));
-                                // } else {
-                                //     userLevelMap['customMetrics'][metric.map] = [formatDimensionOrMetric(metric.value)];
-                                // }
                             } else if (metric.maptype === 'ProductAttributeSelector.Name') {
                                 addTypeToMapping(productLevelMap, 'customMetrics', metric);
-                                
-                                // if (productLevelMap['customMetrics'][metric.map]) {
-                                //     productLevelMap['customMetrics'][metric.map].push(formatDimensionOrMetric(metric.value));
-                                // } else {
-                                //     productLevelMap['customMetrics'][metric.map] = [formatDimensionOrMetric(metric.value)];
-                                // }
                             }
                         });
                     }

--- a/test/tests.js
+++ b/test/tests.js
@@ -178,17 +178,16 @@ describe('Google Analytics Forwarder', function() {
                 customDimensions:
                     '[\
                 {&quot;maptype&quot;:&quot;EventAttributeClass.Name&quot;,&quot;value&quot;:&quot;Dimension 1&quot;,&quot;map&quot;:&quot;color&quot;},\
-                {&quot;maptype&quot;:&quot;EventAttributeClass.Name&quot;,&quot;value&quot;:&quot;Dimension 4&quot;,&quot;map&quot;:&quot;colour&quot;},\
+                {&quot;maptype&quot;:&quot;EventAttributeClass.Name&quot;,&quot;value&quot;:&quot;Dimension 1&quot;,&quot;map&quot;:&quot;colour&quot;},\
                 {&quot;maptype&quot;:&quot;EventAttributeClass.Name&quot;,&quot;value&quot;:&quot;Dimension 2&quot;,&quot;map&quot;:&quot;gender&quot;},\
                 {&quot;maptype&quot;:&quot;EventAttributeClass.Name&quot;,&quot;value&quot;:&quot;Dimension 5&quot;,&quot;map&quot;:&quot;sex&quot;},\
                 {&quot;maptype&quot;:&quot;EventAttributeClass.Name&quot;,&quot;value&quot;:&quot;Dimension 3&quot;,&quot;map&quot;:&quot;size&quot;},\
-                {&quot;maptype&quot;:&quot;EventAttributeClass.Name&quot;,&quot;value&quot;:&quot;Dimension 6&quot;,&quot;map&quot;:&quot;size&quot;},\
                 {&quot;maptype&quot;:&quot;ProductAttributeSelector.Name&quot;,&quot;value&quot;:&quot;Dimension 1&quot;,&quot;map&quot;:&quot;color&quot;},\
                 {&quot;maptype&quot;:&quot;ProductAttributeSelector.Name&quot;,&quot;value&quot;:&quot;Dimension 2&quot;,&quot;map&quot;:&quot;gender&quot;},\
                 {&quot;maptype&quot;:&quot;ProductAttributeSelector.Name&quot;,&quot;value&quot;:&quot;Dimension 3&quot;,&quot;map&quot;:&quot;size&quot;},\
-                {&quot;maptype&quot;:&quot;UserAttributeClass.Name&quot;,&quot;value&quot;:&quot;Dimension 2&quot;,&quot;map&quot;:&quot;color&quot;},\
-                {&quot;maptype&quot;:&quot;UserAttributeClass.Name&quot;,&quot;value&quot;:&quot;Dimension 3&quot;,&quot;map&quot;:&quot;gender&quot;},\
-                {&quot;maptype&quot;:&quot;UserAttributeClass.Name&quot;,&quot;value&quot;:&quot;Dimension 1&quot;,&quot;map&quot;:&quot;size&quot;}\
+                {&quot;maptype&quot;:&quot;UserAttributeClass.Name&quot;,&quot;value&quot;:&quot;Dimension 1&quot;,&quot;map&quot;:&quot;color&quot;},\
+                {&quot;maptype&quot;:&quot;UserAttributeClass.Name&quot;,&quot;value&quot;:&quot;Dimension 2&quot;,&quot;map&quot;:&quot;gender&quot;},\
+                {&quot;maptype&quot;:&quot;UserAttributeClass.Name&quot;,&quot;value&quot;:&quot;Dimension 3&quot;,&quot;map&quot;:&quot;size&quot;}\
             ]',
                 customMetrics:
                     '[\
@@ -211,7 +210,7 @@ describe('Google Analytics Forwarder', function() {
         window._gaq = [];
     });
 
-    xit('should initialize with ampClientId if clientIdentificationType is AMP', function(done) {
+    it('should initialize with ampClientId if clientIdentificationType is AMP', function(done) {
         window.googleanalytics.reset();
 
         mParticle.forwarder.init(
@@ -237,7 +236,7 @@ describe('Google Analytics Forwarder', function() {
         done();
     });
 
-    xit('should change page name for custom flag based on Google.Page', function(done) {
+    it('should change page name for custom flag based on Google.Page', function(done) {
         mParticle.forwarder.process({
             EventDataType: MessageType.PageView,
             EventName: 'Test Page Event',
@@ -256,7 +255,7 @@ describe('Google Analytics Forwarder', function() {
         done();
     });
 
-    xit('should change page name for custom flag based on Google.Title', function(done) {
+    it('should change page name for custom flag based on Google.Title', function(done) {
         mParticle.forwarder.process({
             EventDataType: MessageType.PageView,
             EventName: 'Test Page Event',
@@ -275,7 +274,7 @@ describe('Google Analytics Forwarder', function() {
         done();
     });
 
-    xit('should change page name for custom flag based on both Google.Page and Google.Title', function(done) {
+    it('should change page name for custom flag based on both Google.Page and Google.Title', function(done) {
         mParticle.forwarder.process({
             EventDataType: MessageType.PageView,
             EventName: 'Test Page Event',
@@ -450,7 +449,7 @@ describe('Google Analytics Forwarder', function() {
         done();
     });
 
-    it.only('should log custom dimensions and metrics based on user attribute', function(done) {
+    it('should log custom dimensions and metrics based on user attribute', function(done) {
         mParticle.forwarder.process({
             EventDataType: MessageType.Commerce,
             PromotionAction: {
@@ -473,26 +472,93 @@ describe('Google Analytics Forwarder', function() {
                 players: 3,
             },
         });
-        debugger
-        window.googleanalytics.args[2][4].should.have.property(
+
+        window.googleanalytics.args[1][4].should.have.property(
             'dimension1',
             'blue'
         );
-        window.googleanalytics.args[2][4].should.have.property(
+        window.googleanalytics.args[1][4].should.have.property(
             'dimension2',
             'female'
         );
-        window.googleanalytics.args[2][4].should.have.property(
+        window.googleanalytics.args[1][4].should.have.property(
             'dimension3',
             'large'
         );
-        window.googleanalytics.args[2][4].should.have.property('metric1', 1);
-        window.googleanalytics.args[2][4].should.have.property('metric2', 15);
-        window.googleanalytics.args[2][4].should.have.property('metric3', 3);
+        window.googleanalytics.args[1][4].should.have.property('metric1', 1);
+        window.googleanalytics.args[1][4].should.have.property('metric2', 15);
+        window.googleanalytics.args[1][4].should.have.property('metric3', 3);
         done();
     });
 
-    xit('should log events as non-interaction or interaction when provided with flag', function(done) {
+    it('should allow an attribute to be mapped to multiple dimensions', function(done) {
+        var event = {
+            EventDataType: MessageType.PageEvent,
+            EventName: 'Test Event',
+            EventAttributes: {
+                label: 'label',
+                value: 200,
+                gender: 'male',
+            },
+        };
+        mParticle.forwarder.process(event);
+        window.googleanalytics.args[0][6].should.have.property(
+            'dimension2',
+            'male'
+        );
+
+        var event2 = {
+            EventDataType: MessageType.PageEvent,
+            EventName: 'Test Event',
+            EventAttributes: {
+                label: 'label',
+                value: 200,
+                sex: 'male',
+            },
+        };
+
+        mParticle.forwarder.process(event2);
+        window.googleanalytics.args[1][6].should.have.property(
+            'dimension5',
+            'male'
+        );
+        done();
+    });
+
+    it('should allow multiple attributes to be mapped to the same dimensions', function(done) {
+        var event = {
+            EventDataType: MessageType.PageEvent,
+            EventName: 'Test Event',
+            EventAttributes: {
+                label: 'label',
+                value: 200,
+                colour: 'blue',
+            },
+        };
+        mParticle.forwarder.process(event);
+
+        window.googleanalytics.args[0][6].should.have.property(
+            'dimension1',
+            'blue'
+        );
+        var event2 = {
+            EventDataType: MessageType.PageEvent,
+            EventName: 'Test Event',
+            EventAttributes: {
+                label: 'label',
+                value: 200,
+                color: 'blue',
+            },
+        };
+        mParticle.forwarder.process(event2);
+        window.googleanalytics.args[1][6].should.have.property(
+            'dimension1',
+            'blue'
+        );
+        done();
+    });
+
+    it('should log events as non-interaction or interaction when provided with flag', function(done) {
         mParticle.forwarder.process({
             EventDataType: MessageType.Commerce,
             PromotionAction: {
@@ -519,7 +585,7 @@ describe('Google Analytics Forwarder', function() {
         done();
     });
 
-    xit('should log event', function(done) {
+    it('should log event', function(done) {
         mParticle.forwarder.process({
             EventDataType: MessageType.PageEvent,
             EventName: 'Test Event',
@@ -540,7 +606,7 @@ describe('Google Analytics Forwarder', function() {
         done();
     });
 
-    xit('should log page view', function(done) {
+    it('should log page view', function(done) {
         var event = {
             EventDataType: MessageType.PageView,
         };
@@ -558,7 +624,7 @@ describe('Google Analytics Forwarder', function() {
         done();
     });
 
-    xit('should log commerce event', function(done) {
+    it('should log commerce event', function(done) {
         mParticle.forwarder.process({
             EventDataType: MessageType.Commerce,
             EventCategory: CommerceEventType.ProductPurchase,
@@ -628,7 +694,7 @@ describe('Google Analytics Forwarder', function() {
         done();
     });
 
-    xit('should log refund', function(done) {
+    it('should log refund', function(done) {
         var event = {
             EventDataType: MessageType.Commerce,
             EventCategory: CommerceEventType.ProductRefund,
@@ -671,7 +737,7 @@ describe('Google Analytics Forwarder', function() {
         done();
     });
 
-    xit('should log add to cart', function(done) {
+    it('should log add to cart', function(done) {
         var event = {
             EventDataType: MessageType.Commerce,
             EventCategory: CommerceEventType.ProductAddToCart,
@@ -712,7 +778,7 @@ describe('Google Analytics Forwarder', function() {
         done();
     });
 
-    xit('should log remove from cart', function(done) {
+    it('should log remove from cart', function(done) {
         var event = {
             EventDataType: MessageType.Commerce,
             EventCategory: CommerceEventType.ProductRemoveFromCart,
@@ -756,7 +822,7 @@ describe('Google Analytics Forwarder', function() {
         done();
     });
 
-    xit('should log checkout', function(done) {
+    it('should log checkout', function(done) {
         var event = {
             EventDataType: MessageType.Commerce,
             EventCategory: CommerceEventType.ProductCheckout,
@@ -804,7 +870,7 @@ describe('Google Analytics Forwarder', function() {
         done();
     });
 
-    xit('should log product click', function(done) {
+    it('should log product click', function(done) {
         var event = {
             EventDataType: MessageType.Commerce,
             EventCategory: CommerceEventType.ProductClick,
@@ -955,7 +1021,7 @@ describe('Google Analytics Forwarder', function() {
         done();
     });
 
-    xit('should log promotion view', function(done) {
+    it('should log promotion view', function(done) {
         var event = {
             EventDataType: MessageType.Commerce,
             EventCategory: CommerceEventType.PromotionView,
@@ -1001,7 +1067,7 @@ describe('Google Analytics Forwarder', function() {
         done();
     });
 
-    xit('should log promotion click', function(done) {
+    it('should log promotion click', function(done) {
         mParticle.forwarder.process({
             EventDataType: MessageType.Commerce,
             EventCategory: CommerceEventType.PromotionClick,

--- a/test/tests.js
+++ b/test/tests.js
@@ -298,7 +298,7 @@ describe('Google Analytics Forwarder', function() {
         done();
     });
 
-    it('should log custom dimensions and custom event with an event log', function(done) {
+    it('should log custom dimensions and custom events with an event log', function(done) {
         var event = {
             EventDataType: MessageType.PageEvent,
             EventName: 'Test Event',

--- a/test/tests.js
+++ b/test/tests.js
@@ -176,15 +176,32 @@ describe('Google Analytics Forwarder', function() {
             {
                 useCustomerId: 'True',
                 customDimensions:
-                    '[{ \
-                &quot;maptype&quot;:&quot;EventAttributeClass.Name&quot;,&quot;value&quot;:&quot;Dimension 1&quot;,&quot;map&quot;:&quot;color&quot;},{&quot;maptype&quot;:&quot;EventAttributeClass.Name&quot;,&quot;value&quot;:&quot;Dimension 2&quot;,&quot;map&quot;:&quot;gender&quot;},{&quot;maptype&quot;:&quot;EventAttributeClass.Name&quot;,&quot;value&quot;:&quot;Dimension 3&quot;,&quot;map&quot;:&quot;size&quot;}, \
-                {&quot;maptype&quot;:&quot;ProductAttributeSelector.Name&quot;,&quot;value&quot;:&quot;Dimension 1&quot;,&quot;map&quot;:&quot;color&quot;},{&quot;maptype&quot;:&quot;ProductAttributeSelector.Name&quot;,&quot;value&quot;:&quot;Dimension 2&quot;,&quot;map&quot;:&quot;gender&quot;},{&quot;maptype&quot;:&quot;ProductAttributeSelector.Name&quot;,&quot;value&quot;:&quot;Dimension 3&quot;,&quot;map&quot;:&quot;size&quot;}, \
-                {&quot;maptype&quot;:&quot;UserAttributeClass.Name&quot;,&quot;value&quot;:&quot;Dimension 1&quot;,&quot;map&quot;:&quot;color&quot;},{&quot;maptype&quot;:&quot;UserAttributeClass.Name&quot;,&quot;value&quot;:&quot;Dimension 2&quot;,&quot;map&quot;:&quot;gender&quot;},{&quot;maptype&quot;:&quot;UserAttributeClass.Name&quot;,&quot;value&quot;:&quot;Dimension 3&quot;,&quot;map&quot;:&quot;size&quot;}]',
-
+                    '[\
+                {&quot;maptype&quot;:&quot;EventAttributeClass.Name&quot;,&quot;value&quot;:&quot;Dimension 1&quot;,&quot;map&quot;:&quot;color&quot;},\
+                {&quot;maptype&quot;:&quot;EventAttributeClass.Name&quot;,&quot;value&quot;:&quot;Dimension 4&quot;,&quot;map&quot;:&quot;colour&quot;},\
+                {&quot;maptype&quot;:&quot;EventAttributeClass.Name&quot;,&quot;value&quot;:&quot;Dimension 2&quot;,&quot;map&quot;:&quot;gender&quot;},\
+                {&quot;maptype&quot;:&quot;EventAttributeClass.Name&quot;,&quot;value&quot;:&quot;Dimension 5&quot;,&quot;map&quot;:&quot;sex&quot;},\
+                {&quot;maptype&quot;:&quot;EventAttributeClass.Name&quot;,&quot;value&quot;:&quot;Dimension 3&quot;,&quot;map&quot;:&quot;size&quot;},\
+                {&quot;maptype&quot;:&quot;EventAttributeClass.Name&quot;,&quot;value&quot;:&quot;Dimension 6&quot;,&quot;map&quot;:&quot;size&quot;},\
+                {&quot;maptype&quot;:&quot;ProductAttributeSelector.Name&quot;,&quot;value&quot;:&quot;Dimension 1&quot;,&quot;map&quot;:&quot;color&quot;},\
+                {&quot;maptype&quot;:&quot;ProductAttributeSelector.Name&quot;,&quot;value&quot;:&quot;Dimension 2&quot;,&quot;map&quot;:&quot;gender&quot;},\
+                {&quot;maptype&quot;:&quot;ProductAttributeSelector.Name&quot;,&quot;value&quot;:&quot;Dimension 3&quot;,&quot;map&quot;:&quot;size&quot;},\
+                {&quot;maptype&quot;:&quot;UserAttributeClass.Name&quot;,&quot;value&quot;:&quot;Dimension 2&quot;,&quot;map&quot;:&quot;color&quot;},\
+                {&quot;maptype&quot;:&quot;UserAttributeClass.Name&quot;,&quot;value&quot;:&quot;Dimension 3&quot;,&quot;map&quot;:&quot;gender&quot;},\
+                {&quot;maptype&quot;:&quot;UserAttributeClass.Name&quot;,&quot;value&quot;:&quot;Dimension 1&quot;,&quot;map&quot;:&quot;size&quot;}\
+            ]',
                 customMetrics:
-                    '[{&quot;maptype&quot;:&quot;EventAttributeClass.Name&quot;,&quot;value&quot;:&quot;Metric 1&quot;,&quot;map&quot;:&quot;levels&quot;},{&quot;maptype&quot;:&quot;EventAttributeClass.Name&quot;,&quot;value&quot;:&quot;Metric 2&quot;,&quot;map&quot;:&quot;shots&quot;},{&quot;maptype&quot;:&quot;EventAttributeClass.Name&quot;,&quot;value&quot;:&quot;Metric 3&quot;,&quot;map&quot;:&quot;players&quot;}, \
-                {&quot;maptype&quot;:&quot;ProductAttributeSelector.Name&quot;,&quot;value&quot;:&quot;Metric 1&quot;,&quot;map&quot;:&quot;levels&quot;},{&quot;maptype&quot;:&quot;ProductAttributeSelector.Name&quot;,&quot;value&quot;:&quot;Metric 2&quot;,&quot;map&quot;:&quot;shots&quot;},{&quot;maptype&quot;:&quot;ProductAttributeSelector.Name&quot;,&quot;value&quot;:&quot;Metric 3&quot;,&quot;map&quot;:&quot;players&quot;}, \
-                {&quot;maptype&quot;:&quot;UserAttributeClass.Name&quot;,&quot;value&quot;:&quot;Metric 1&quot;,&quot;map&quot;:&quot;levels&quot;},{&quot;maptype&quot;:&quot;UserAttributeClass.Name&quot;,&quot;value&quot;:&quot;Metric 2&quot;,&quot;map&quot;:&quot;shots&quot;},{&quot;maptype&quot;:&quot;UserAttributeClass.Name&quot;,&quot;value&quot;:&quot;Metric 3&quot;,&quot;map&quot;:&quot;players&quot;}]',
+                    '[\
+                {&quot;maptype&quot;:&quot;EventAttributeClass.Name&quot;,&quot;value&quot;:&quot;Metric 1&quot;,&quot;map&quot;:&quot;levels&quot;},\
+                {&quot;maptype&quot;:&quot;EventAttributeClass.Name&quot;,&quot;value&quot;:&quot;Metric 2&quot;,&quot;map&quot;:&quot;shots&quot;},\
+                {&quot;maptype&quot;:&quot;EventAttributeClass.Name&quot;,&quot;value&quot;:&quot;Metric 3&quot;,&quot;map&quot;:&quot;players&quot;},\
+                {&quot;maptype&quot;:&quot;ProductAttributeSelector.Name&quot;,&quot;value&quot;:&quot;Metric 1&quot;,&quot;map&quot;:&quot;levels&quot;},\
+                {&quot;maptype&quot;:&quot;ProductAttributeSelector.Name&quot;,&quot;value&quot;:&quot;Metric 2&quot;,&quot;map&quot;:&quot;shots&quot;},\
+                {&quot;maptype&quot;:&quot;ProductAttributeSelector.Name&quot;,&quot;value&quot;:&quot;Metric 3&quot;,&quot;map&quot;:&quot;players&quot;},\
+                {&quot;maptype&quot;:&quot;UserAttributeClass.Name&quot;,&quot;value&quot;:&quot;Metric 1&quot;,&quot;map&quot;:&quot;levels&quot;},\
+                {&quot;maptype&quot;:&quot;UserAttributeClass.Name&quot;,&quot;value&quot;:&quot;Metric 2&quot;,&quot;map&quot;:&quot;shots&quot;},\
+                {&quot;maptype&quot;:&quot;UserAttributeClass.Name&quot;,&quot;value&quot;:&quot;Metric 3&quot;,&quot;map&quot;:&quot;players&quot;}\
+                ]',
             },
             reportService.cb,
             true,
@@ -194,7 +211,7 @@ describe('Google Analytics Forwarder', function() {
         window._gaq = [];
     });
 
-    it('should initialize with ampClientId if clientIdentificationType is AMP', function(done) {
+    xit('should initialize with ampClientId if clientIdentificationType is AMP', function(done) {
         window.googleanalytics.reset();
 
         mParticle.forwarder.init(
@@ -220,7 +237,7 @@ describe('Google Analytics Forwarder', function() {
         done();
     });
 
-    it('should change page name for custom flag based on Google.Page', function(done) {
+    xit('should change page name for custom flag based on Google.Page', function(done) {
         mParticle.forwarder.process({
             EventDataType: MessageType.PageView,
             EventName: 'Test Page Event',
@@ -239,7 +256,7 @@ describe('Google Analytics Forwarder', function() {
         done();
     });
 
-    it('should change page name for custom flag based on Google.Title', function(done) {
+    xit('should change page name for custom flag based on Google.Title', function(done) {
         mParticle.forwarder.process({
             EventDataType: MessageType.PageView,
             EventName: 'Test Page Event',
@@ -258,7 +275,7 @@ describe('Google Analytics Forwarder', function() {
         done();
     });
 
-    it('should change page name for custom flag based on both Google.Page and Google.Title', function(done) {
+    xit('should change page name for custom flag based on both Google.Page and Google.Title', function(done) {
         mParticle.forwarder.process({
             EventDataType: MessageType.PageView,
             EventName: 'Test Page Event',
@@ -282,7 +299,7 @@ describe('Google Analytics Forwarder', function() {
         done();
     });
 
-    it('should log custom dimensions and custom event with an event log and custom flag', function(done) {
+    it('should log custom dimensions and custom event with an event log', function(done) {
         var event = {
             EventDataType: MessageType.PageEvent,
             EventName: 'Test Event',
@@ -433,7 +450,7 @@ describe('Google Analytics Forwarder', function() {
         done();
     });
 
-    it('should log custom dimensions and metrics based on user attribute', function(done) {
+    it.only('should log custom dimensions and metrics based on user attribute', function(done) {
         mParticle.forwarder.process({
             EventDataType: MessageType.Commerce,
             PromotionAction: {
@@ -456,26 +473,26 @@ describe('Google Analytics Forwarder', function() {
                 players: 3,
             },
         });
-
-        window.googleanalytics.args[1][4].should.have.property(
+        debugger
+        window.googleanalytics.args[2][4].should.have.property(
             'dimension1',
             'blue'
         );
-        window.googleanalytics.args[1][4].should.have.property(
+        window.googleanalytics.args[2][4].should.have.property(
             'dimension2',
             'female'
         );
-        window.googleanalytics.args[1][4].should.have.property(
+        window.googleanalytics.args[2][4].should.have.property(
             'dimension3',
             'large'
         );
-        window.googleanalytics.args[1][4].should.have.property('metric1', 1);
-        window.googleanalytics.args[1][4].should.have.property('metric2', 15);
-        window.googleanalytics.args[1][4].should.have.property('metric3', 3);
+        window.googleanalytics.args[2][4].should.have.property('metric1', 1);
+        window.googleanalytics.args[2][4].should.have.property('metric2', 15);
+        window.googleanalytics.args[2][4].should.have.property('metric3', 3);
         done();
     });
 
-    it('should log events as non-interaction or interaction when provided with flag', function(done) {
+    xit('should log events as non-interaction or interaction when provided with flag', function(done) {
         mParticle.forwarder.process({
             EventDataType: MessageType.Commerce,
             PromotionAction: {
@@ -502,7 +519,7 @@ describe('Google Analytics Forwarder', function() {
         done();
     });
 
-    it('should log event', function(done) {
+    xit('should log event', function(done) {
         mParticle.forwarder.process({
             EventDataType: MessageType.PageEvent,
             EventName: 'Test Event',
@@ -523,7 +540,7 @@ describe('Google Analytics Forwarder', function() {
         done();
     });
 
-    it('should log page view', function(done) {
+    xit('should log page view', function(done) {
         var event = {
             EventDataType: MessageType.PageView,
         };
@@ -541,7 +558,7 @@ describe('Google Analytics Forwarder', function() {
         done();
     });
 
-    it('should log commerce event', function(done) {
+    xit('should log commerce event', function(done) {
         mParticle.forwarder.process({
             EventDataType: MessageType.Commerce,
             EventCategory: CommerceEventType.ProductPurchase,
@@ -611,7 +628,7 @@ describe('Google Analytics Forwarder', function() {
         done();
     });
 
-    it('should log refund', function(done) {
+    xit('should log refund', function(done) {
         var event = {
             EventDataType: MessageType.Commerce,
             EventCategory: CommerceEventType.ProductRefund,
@@ -654,7 +671,7 @@ describe('Google Analytics Forwarder', function() {
         done();
     });
 
-    it('should log add to cart', function(done) {
+    xit('should log add to cart', function(done) {
         var event = {
             EventDataType: MessageType.Commerce,
             EventCategory: CommerceEventType.ProductAddToCart,
@@ -695,7 +712,7 @@ describe('Google Analytics Forwarder', function() {
         done();
     });
 
-    it('should log remove from cart', function(done) {
+    xit('should log remove from cart', function(done) {
         var event = {
             EventDataType: MessageType.Commerce,
             EventCategory: CommerceEventType.ProductRemoveFromCart,
@@ -739,7 +756,7 @@ describe('Google Analytics Forwarder', function() {
         done();
     });
 
-    it('should log checkout', function(done) {
+    xit('should log checkout', function(done) {
         var event = {
             EventDataType: MessageType.Commerce,
             EventCategory: CommerceEventType.ProductCheckout,
@@ -787,7 +804,7 @@ describe('Google Analytics Forwarder', function() {
         done();
     });
 
-    it('should log product click', function(done) {
+    xit('should log product click', function(done) {
         var event = {
             EventDataType: MessageType.Commerce,
             EventCategory: CommerceEventType.ProductClick,
@@ -938,7 +955,7 @@ describe('Google Analytics Forwarder', function() {
         done();
     });
 
-    it('should log promotion view', function(done) {
+    xit('should log promotion view', function(done) {
         var event = {
             EventDataType: MessageType.Commerce,
             EventCategory: CommerceEventType.PromotionView,
@@ -984,7 +1001,7 @@ describe('Google Analytics Forwarder', function() {
         done();
     });
 
-    it('should log promotion click', function(done) {
+    xit('should log promotion click', function(done) {
         mParticle.forwarder.process({
             EventDataType: MessageType.Commerce,
             EventCategory: CommerceEventType.PromotionClick,


### PR DESCRIPTION
Previously when parsing mapped attributes, an event level mapping where `fooAttr1` is mapped to `dimension1` and `dimension2`, and `fooAttr2` is mapped to `dimension3` and `dimension4` would be mapped as follows:
```
eventAttributes = {
   fooAttr1: 'dimension2,
   fooAttr2: 'dimension4'
}
```

In the above case, the second dimension mapped wins out because we are overwriting the key a single string and not considering a scenario where an attribute can be mapped to multiple dimensions.

In this PR, the attributes are now mapped with an array as a key so that we consider multiple dimensions per attribute:
```
eventAttributes = {
   fooAttr1: ['dimension1', 'dimension2'],
   fooAttr2: ['dimension3', 'dimension4']
}
```