### PR TITLE
Feat/user timing

### DIFF
--- a/src/GoogleAnalyticsEventForwarder.js
+++ b/src/GoogleAnalyticsEventForwarder.js
@@ -421,7 +421,7 @@
 
         function sendOptionalUserTimingMessage(event, outputDimensionsAndMetrics) {
             // only if there is a custom flag of Google.UserTiming should a user timing message be sent
-            if (event.CustomFlags && event.CustomFlags[USERTIMING]) {
+            if (event.CustomFlags && event.CustomFlags[USERTIMING] && typeof(event.CustomFlags[USERTIMING]) === 'number') {
                 var userTimingObject = {
                     hitType: 'timing',
                     timingVar: event.EventName,
@@ -431,7 +431,7 @@
                 if (event.CustomFlags[CATEGORY]) {
                     userTimingObject.timingCategory = event.CustomFlags[CATEGORY];
                 } else {
-                    console.warn('A Google Analytics User Timing event requires a custom flag of Google.Category. User Timing event not sent')
+                    console.warn('A Google Analytics User Timing event requires a custom flag of Google.Category. User Timing event not sent.')
                     return;
                 }
                 if (event.CustomFlags[LABEL]) {

--- a/src/GoogleAnalyticsEventForwarder.js
+++ b/src/GoogleAnalyticsEventForwarder.js
@@ -428,11 +428,14 @@
                     timingValue: event.CustomFlags[USERTIMING]
                 };
 
-                if (event.CustomFlags[LABEL]) {
-                    userTimingObject.timingLabel = event.CustomFlags[LABEL];
-                }
                 if (event.CustomFlags[CATEGORY]) {
                     userTimingObject.timingCategory = event.CustomFlags[CATEGORY];
+                } else {
+                    console.warn('A Google Analytics User Timing event requires a custom flag of Google.Category. User Timing event not sent')
+                    return;
+                }
+                if (event.CustomFlags[LABEL]) {
+                    userTimingObject.timingLabel = event.CustomFlags[LABEL];
                 }
 
                 for (var key in outputDimensionsAndMetrics) {

--- a/src/GoogleAnalyticsEventForwarder.js
+++ b/src/GoogleAnalyticsEventForwarder.js
@@ -355,18 +355,18 @@
             }
         }
 
-        function logEvent(data, outputDimensionsAndMetrics, customFlags) {
+        function logEvent(event, outputDimensionsAndMetrics, customFlags) {
             var label = '',
-                category = getEventTypeName(data.EventCategory),
+                category = getEventTypeName(event.EventCategory),
                 value;
 
-            if (data.EventAttributes) {
-                if (data.EventAttributes.label) {
-                    label = data.EventAttributes.label;
+            if (event.EventAttributes) {
+                if (event.EventAttributes.label) {
+                    label = event.EventAttributes.label;
                 }
 
-                if (data.EventAttributes.value) {
-                    value = parseInt(data.EventAttributes.value, 10);
+                if (event.EventAttributes.value) {
+                    value = parseInt(event.EventAttributes.value, 10);
 
                     // Test for NaN
                     if (value != value) {
@@ -374,15 +374,15 @@
                     }
                 }
 
-                if (data.EventAttributes.category) {
-                    category = data.EventAttributes.category;
+                if (event.EventAttributes.category) {
+                    category = event.EventAttributes.category;
                 }
             }
 
-            if (data.CustomFlags) {
-                var googleCategory = data.CustomFlags[CATEGORY],
-                    googleLabel = data.CustomFlags[LABEL],
-                    googleValue = parseInt(data.CustomFlags[VALUE], 10);
+            if (event.CustomFlags) {
+                var googleCategory = event.CustomFlags[CATEGORY],
+                    googleLabel = event.CustomFlags[LABEL],
+                    googleValue = parseInt(event.CustomFlags[VALUE], 10);
 
                 if (googleCategory) {
                     category = googleCategory;
@@ -401,7 +401,7 @@
             if (forwarderSettings.classicMode == 'True') {
                 _gaq.push(['_trackEvent',
                     category,
-                    data.EventName,
+                    event.EventName,
                     label,
                     value]);
             }
@@ -409,13 +409,13 @@
                 ga(createCmd('send'),
                     customFlags && customFlags[HITTYPE] ? customFlags[HITTYPE] : 'event',
                     category,
-                    data.EventName,
+                    event.EventName,
                     label,
                     value,
                     outputDimensionsAndMetrics
                 );
 
-                sendOptionalUserTimingMessage(data, outputDimensionsAndMetrics);
+                sendOptionalUserTimingMessage(event, outputDimensionsAndMetrics);
             }
         }
 

--- a/src/GoogleAnalyticsEventForwarder.js
+++ b/src/GoogleAnalyticsEventForwarder.js
@@ -425,18 +425,10 @@
                 var userTimingObject = {
                     hitType: 'timing',
                     timingVar: event.EventName,
-                    timingValue: event.CustomFlags[USERTIMING]
+                    timingValue: event.CustomFlags[USERTIMING],
+                    timingCategory: event.CustomFlags[CATEGORY] || getEventTypeName(event.EventCategory),
+                    timingLabel: event.CustomFlags[LABEL] || null,
                 };
-
-                if (event.CustomFlags[CATEGORY]) {
-                    userTimingObject.timingCategory = event.CustomFlags[CATEGORY];
-                } else {
-                    console.warn('A Google Analytics User Timing event requires a custom flag of Google.Category. User Timing event not sent.')
-                    return;
-                }
-                if (event.CustomFlags[LABEL]) {
-                    userTimingObject.timingLabel = event.CustomFlags[LABEL];
-                }
 
                 for (var key in outputDimensionsAndMetrics) {
                     if (outputDimensionsAndMetrics.hasOwnProperty(key)) {

--- a/src/GoogleAnalyticsEventForwarder.js
+++ b/src/GoogleAnalyticsEventForwarder.js
@@ -489,7 +489,7 @@
                                 (i[r].q = i[r].q || []).push(arguments);
                             }, i[r].l = 1 * new Date(); a = s.createElement(o),
                             m = s.getElementsByTagName(o)[0]; a.async = 1; a.src = g; m.parentNode.insertBefore(a, m);
-                        })(window, document, 'script', 'https://www.google-analytics.com/analytics.js', 'ga');
+                        })(window, document, 'script', '//www.google-analytics.com/analytics.js', 'ga');
                     }
 
                     var fieldsObject = {

--- a/test/tests.js
+++ b/test/tests.js
@@ -180,8 +180,10 @@ describe('Google Analytics Forwarder', function() {
                 {&quot;maptype&quot;:&quot;EventAttributeClass.Name&quot;,&quot;value&quot;:&quot;Dimension 1&quot;,&quot;map&quot;:&quot;color&quot;},\
                 {&quot;maptype&quot;:&quot;EventAttributeClass.Name&quot;,&quot;value&quot;:&quot;Dimension 1&quot;,&quot;map&quot;:&quot;colour&quot;},\
                 {&quot;maptype&quot;:&quot;EventAttributeClass.Name&quot;,&quot;value&quot;:&quot;Dimension 2&quot;,&quot;map&quot;:&quot;gender&quot;},\
+                {&quot;maptype&quot;:&quot;EventAttributeClass.Name&quot;,&quot;value&quot;:&quot;Dimension 5&quot;,&quot;map&quot;:&quot;gender&quot;},\
                 {&quot;maptype&quot;:&quot;EventAttributeClass.Name&quot;,&quot;value&quot;:&quot;Dimension 5&quot;,&quot;map&quot;:&quot;sex&quot;},\
                 {&quot;maptype&quot;:&quot;EventAttributeClass.Name&quot;,&quot;value&quot;:&quot;Dimension 3&quot;,&quot;map&quot;:&quot;size&quot;},\
+                {&quot;maptype&quot;:&quot;EventAttributeClass.Name&quot;,&quot;value&quot;:&quot;Dimension 4&quot;,&quot;map&quot;:&quot;color&quot;},\
                 {&quot;maptype&quot;:&quot;ProductAttributeSelector.Name&quot;,&quot;value&quot;:&quot;Dimension 1&quot;,&quot;map&quot;:&quot;color&quot;},\
                 {&quot;maptype&quot;:&quot;ProductAttributeSelector.Name&quot;,&quot;value&quot;:&quot;Dimension 2&quot;,&quot;map&quot;:&quot;gender&quot;},\
                 {&quot;maptype&quot;:&quot;ProductAttributeSelector.Name&quot;,&quot;value&quot;:&quot;Dimension 3&quot;,&quot;map&quot;:&quot;size&quot;},\
@@ -502,26 +504,16 @@ describe('Google Analytics Forwarder', function() {
             },
         };
         mParticle.forwarder.process(event);
+
         window.googleanalytics.args[0][6].should.have.property(
             'dimension2',
             'male'
         );
-
-        var event2 = {
-            EventDataType: MessageType.PageEvent,
-            EventName: 'Test Event',
-            EventAttributes: {
-                label: 'label',
-                value: 200,
-                sex: 'male',
-            },
-        };
-
-        mParticle.forwarder.process(event2);
-        window.googleanalytics.args[1][6].should.have.property(
+        window.googleanalytics.args[0][6].should.have.property(
             'dimension5',
             'male'
         );
+
         done();
     });
 
@@ -1107,6 +1099,311 @@ describe('Google Analytics Forwarder', function() {
         window.googleanalytics.args[2][1].should.equal('event');
         window.googleanalytics.args[2][2].should.equal('eCommerce');
         window.googleanalytics.args[2][3].should.equal('Promotion Click');
+
+        done();
+    });
+
+    it('should log page event along with user timing event when custom flags are passed', function(done) {
+        mParticle.forwarder.process({
+            EventDataType: MessageType.PageEvent,
+            EventName: 'Test Page Event',
+            CustomFlags: {
+                'Google.Label': 'Custom Label',
+                'Google.UserTiming': 500,
+                'Google.Category': 'Custom Category',
+            },
+            EventCategory: EventType.Location,
+            EventAttributes: {
+                label: 'label',
+                value: 200,
+                category: 'category',
+                gender: 'female',
+                color: 'blue',
+                size: 'large',
+                levels: 1,
+                shots: 15,
+                players: 3,
+            },
+        });
+
+        // regular GA event
+        window.googleanalytics.args[0][0].should.equal('tracker-name.send');
+        window.googleanalytics.args[0][1].should.equal('event');
+        window.googleanalytics.args[0][2].should.equal('Custom Category');
+        window.googleanalytics.args[0][3].should.equal('Test Page Event');
+        window.googleanalytics.args[0][4].should.equal('Custom Label');
+        window.googleanalytics.args[0][5].should.equal(200);
+        window.googleanalytics.args[0][6].should.have.property(
+            'dimension1',
+            'blue'
+        );
+        window.googleanalytics.args[0][6].should.have.property(
+            'dimension2',
+            'female'
+        );
+        window.googleanalytics.args[0][6].should.have.property(
+            'dimension3',
+            'large'
+        );
+        window.googleanalytics.args[0][6].should.have.property('metric1', 1);
+        window.googleanalytics.args[0][6].should.have.property('metric2', 15);
+        window.googleanalytics.args[0][6].should.have.property('metric3', 3);
+
+        // user timing event
+        window.googleanalytics.args[1][0].should.equal('tracker-name.send');
+        window.googleanalytics.args[1][1].hitType.should.equal('timing');
+        window.googleanalytics.args[1][1].timingCategory.should.equal(
+            'Custom Category'
+        );
+        window.googleanalytics.args[1][1].timingValue.should.equal(500);
+        window.googleanalytics.args[1][1].timingLabel.should.equal(
+            'Custom Label'
+        );
+        window.googleanalytics.args[1][1].timingVar.should.equal(
+            'Test Page Event'
+        );
+        window.googleanalytics.args[1][1].should.have.property(
+            'dimension1',
+            'blue'
+        );
+        window.googleanalytics.args[1][1].should.have.property(
+            'dimension2',
+            'female'
+        );
+        window.googleanalytics.args[1][1].should.have.property(
+            'dimension3',
+            'large'
+        );
+        window.googleanalytics.args[1][1].should.have.property('metric1', 1);
+        window.googleanalytics.args[1][1].should.have.property('metric2', 15);
+        window.googleanalytics.args[1][1].should.have.property('metric3', 3);
+        done();
+    });
+
+    it('should log regular page event along with user timing event when custom flags are passed ', function(done) {
+        mParticle.forwarder.process({
+            EventDataType: MessageType.PageEvent,
+            EventName: 'Test Page Event',
+            CustomFlags: {
+                'Google.Label': 'Custom Label',
+                'Google.UserTiming': 500,
+                'Google.Category': 'Custom Category',
+            },
+            EventCategory: EventType.Location,
+            EventAttributes: {
+                label: 'label',
+                value: 200,
+                category: 'category',
+                gender: 'female',
+                color: 'blue',
+                size: 'large',
+                levels: 1,
+                shots: 15,
+                players: 3,
+            },
+        });
+
+        // regular GA event
+        window.googleanalytics.args[0][0].should.equal('tracker-name.send');
+        window.googleanalytics.args[0][1].should.equal('event');
+        window.googleanalytics.args[0][2].should.equal('Custom Category');
+        window.googleanalytics.args[0][3].should.equal('Test Page Event');
+        window.googleanalytics.args[0][4].should.equal('Custom Label');
+        window.googleanalytics.args[0][5].should.equal(200);
+        window.googleanalytics.args[0][6].should.have.property(
+            'dimension1',
+            'blue'
+        );
+        window.googleanalytics.args[0][6].should.have.property(
+            'dimension2',
+            'female'
+        );
+        window.googleanalytics.args[0][6].should.have.property(
+            'dimension3',
+            'large'
+        );
+        window.googleanalytics.args[0][6].should.have.property('metric1', 1);
+        window.googleanalytics.args[0][6].should.have.property('metric2', 15);
+        window.googleanalytics.args[0][6].should.have.property('metric3', 3);
+
+        // user timing event
+        window.googleanalytics.args[1][0].should.equal('tracker-name.send');
+        window.googleanalytics.args[1][1].hitType.should.equal('timing');
+        window.googleanalytics.args[1][1].timingCategory.should.equal(
+            'Custom Category'
+        );
+        window.googleanalytics.args[1][1].timingValue.should.equal(500);
+        window.googleanalytics.args[1][1].timingLabel.should.equal(
+            'Custom Label'
+        );
+        window.googleanalytics.args[1][1].timingVar.should.equal(
+            'Test Page Event'
+        );
+        window.googleanalytics.args[1][1].should.have.property(
+            'dimension1',
+            'blue'
+        );
+        window.googleanalytics.args[1][1].should.have.property(
+            'dimension2',
+            'female'
+        );
+        window.googleanalytics.args[1][1].should.have.property(
+            'dimension3',
+            'large'
+        );
+        window.googleanalytics.args[1][1].should.have.property('metric1', 1);
+        window.googleanalytics.args[1][1].should.have.property('metric2', 15);
+        window.googleanalytics.args[1][1].should.have.property('metric3', 3);
+
+        done();
+    });
+
+    it('should log page view along with user timing event when custom flags are passed', function(done) {
+        var event = {
+            EventName: 'PageView',
+            EventDataType: MessageType.PageView,
+            CustomFlags: {
+                'Google.Label': 'Custom Label',
+                'Google.UserTiming': 500,
+                'Google.Category': 'Custom Category',
+            },
+        };
+        mParticle.forwarder.process(event);
+
+        window.googleanalytics.args[0][0].should.equal('tracker-name.send');
+        window.googleanalytics.args[0][1].should.equal('pageview');
+
+        // user timing event
+        window.googleanalytics.args[1][0].should.equal('tracker-name.send');
+        window.googleanalytics.args[1][1].hitType.should.equal('timing');
+        window.googleanalytics.args[1][1].timingCategory.should.equal(
+            'Custom Category'
+        );
+        window.googleanalytics.args[1][1].timingValue.should.equal(500);
+        window.googleanalytics.args[1][1].timingLabel.should.equal(
+            'Custom Label'
+        );
+        window.googleanalytics.args[1][1].timingVar.should.equal('PageView');
+
+        done();
+    });
+
+    it('should log page view along with user timing event when custom flags are passed', function(done) {
+        var event = {
+            EventName: 'PageView',
+            EventDataType: MessageType.PageView,
+            CustomFlags: {
+                'Google.Label': 'Custom Label',
+                'Google.UserTiming': 500,
+                'Google.Category': 'Custom Category',
+            },
+        };
+        mParticle.forwarder.process(event);
+
+        window.googleanalytics.args[0][0].should.equal('tracker-name.send');
+        window.googleanalytics.args[0][1].should.equal('pageview');
+
+        // user timing event
+        window.googleanalytics.args[1][0].should.equal('tracker-name.send');
+        window.googleanalytics.args[1][1].hitType.should.equal('timing');
+        window.googleanalytics.args[1][1].timingCategory.should.equal(
+            'Custom Category'
+        );
+        window.googleanalytics.args[1][1].timingValue.should.equal(500);
+        window.googleanalytics.args[1][1].timingLabel.should.equal(
+            'Custom Label'
+        );
+        window.googleanalytics.args[1][1].timingVar.should.equal('PageView');
+
+        done();
+    });
+
+    it('should log commerce event along with user timing event when custom flags are passed ', function(done) {
+        mParticle.forwarder.process({
+            EventName: 'eCommerce - Purchase',
+            EventDataType: MessageType.Commerce,
+            EventCategory: CommerceEventType.ProductPurchase,
+            ProductAction: {
+                ProductActionType: ProductActionType.Purchase,
+                ProductList: [
+                    {
+                        Sku: '12345',
+                        Name: 'iPhone 6',
+                        Category: 'Phones',
+                        Brand: 'iPhone',
+                        Variant: '6',
+                        Price: 400,
+                        CouponCode: null,
+                        Quantity: 1,
+                    },
+                ],
+                TransactionId: 123,
+                Affiliation: 'my-affiliation',
+                TotalAmount: 450,
+                TaxAmount: 40,
+                ShippingAmount: 10,
+                CouponCode: null,
+            },
+            CustomFlags: {
+                'Google.Label': 'Custom Label',
+                'Google.UserTiming': 500,
+                'Google.Category': 'Custom Category',
+            },
+        });
+
+        window.googleanalytics.args[0][0].should.equal(
+            'tracker-name.ec:addProduct'
+        );
+        window.googleanalytics.args[0][1].should.have.property('id', '12345');
+        window.googleanalytics.args[0][1].should.have.property(
+            'name',
+            'iPhone 6'
+        );
+        window.googleanalytics.args[0][1].should.have.property(
+            'category',
+            'Phones'
+        );
+        window.googleanalytics.args[0][1].should.have.property(
+            'brand',
+            'iPhone'
+        );
+        window.googleanalytics.args[0][1].should.have.property('variant', '6');
+        window.googleanalytics.args[0][1].should.have.property('price', 400);
+        window.googleanalytics.args[0][1].should.have.property('coupon', null);
+        window.googleanalytics.args[0][1].should.have.property('quantity', 1);
+
+        window.googleanalytics.args[1][0].should.equal(
+            'tracker-name.ec:setAction'
+        );
+        window.googleanalytics.args[1][1].should.equal('purchase');
+        window.googleanalytics.args[1][2].should.have.property('id', 123);
+        window.googleanalytics.args[1][2].should.have.property(
+            'affiliation',
+            'my-affiliation'
+        );
+        window.googleanalytics.args[1][2].should.have.property('revenue', 450);
+        window.googleanalytics.args[1][2].should.have.property('tax', 40);
+        window.googleanalytics.args[1][2].should.have.property('shipping', 10);
+        window.googleanalytics.args[1][2].should.have.property('coupon', null);
+
+        window.googleanalytics.args[2][0].should.equal('tracker-name.send');
+        window.googleanalytics.args[2][1].should.equal('event');
+        window.googleanalytics.args[2][2].should.equal('eCommerce');
+        window.googleanalytics.args[2][3].should.equal('Product Purchased');
+
+        // user timing event
+        window.googleanalytics.args[3][0].should.equal('tracker-name.send');
+        window.googleanalytics.args[3][1].hitType.should.equal('timing');
+        window.googleanalytics.args[3][1].timingCategory.should.equal(
+            'Custom Category'
+        );
+        window.googleanalytics.args[3][1].timingValue.should.equal(500);
+        window.googleanalytics.args[3][1].timingLabel.should.equal(
+            'Custom Label'
+        );
+        window.googleanalytics.args[3][1].timingVar.should.equal(
+            'eCommerce - Purchase'
+        );
 
         done();
     });

--- a/test/tests.js
+++ b/test/tests.js
@@ -1431,4 +1431,32 @@ describe('Google Analytics Forwarder', function() {
 
         done();
     });
+
+    it('should pass EventCategory to a user timing event if Google.Category custom flag not passed', function(done) {
+        mParticle.forwarder.process({
+            EventDataType: MessageType.PageEvent,
+            EventName: 'Test Page Event',
+            CustomFlags: {
+                'Google.Label': 'Custom Label',
+                'Google.UserTiming': 500,
+            },
+            EventCategory: EventType.Location,
+        });
+
+        // regular GA event
+        window.googleanalytics.args[0][0].should.equal('tracker-name.send');
+        window.googleanalytics.args[0][1].should.equal('event');
+        window.googleanalytics.args[0][2].should.equal('Location');
+        window.googleanalytics.args[0][3].should.equal('Test Page Event');
+        window.googleanalytics.args[0][4].should.equal('Custom Label');
+
+        // user timing event should not exist
+        window.googleanalytics.args[1][0].should.equal('tracker-name.send');
+        window.googleanalytics.args[1][1].hitType.should.equal('timing');
+        window.googleanalytics.args[1][1].timingCategory.should.equal(
+            'Location'
+        );
+
+        done();
+    });
 });

--- a/test/tests.js
+++ b/test/tests.js
@@ -1407,4 +1407,29 @@ describe('Google Analytics Forwarder', function() {
 
         done();
     });
+
+    it("should not log a user timing event if Google.UserTiming is not of type 'number'", function(done) {
+        mParticle.forwarder.process({
+            EventDataType: MessageType.PageEvent,
+            EventName: 'Test Page Event',
+            CustomFlags: {
+                'Google.Label': 'Custom Label',
+                'Google.UserTiming': '500',
+                'Google.Category': 'Custom Category',
+            },
+            EventCategory: EventType.Location,
+        });
+
+        // regular GA event
+        window.googleanalytics.args[0][0].should.equal('tracker-name.send');
+        window.googleanalytics.args[0][1].should.equal('event');
+        window.googleanalytics.args[0][2].should.equal('Custom Category');
+        window.googleanalytics.args[0][3].should.equal('Test Page Event');
+        window.googleanalytics.args[0][4].should.equal('Custom Label');
+
+        // user timing event should not exist
+        window.googleanalytics.args.length.should.equal(1);
+
+        done();
+    });
 });

--- a/test/tests.js
+++ b/test/tests.js
@@ -183,7 +183,6 @@ describe('Google Analytics Forwarder', function() {
                 {&quot;maptype&quot;:&quot;EventAttributeClass.Name&quot;,&quot;value&quot;:&quot;Dimension 5&quot;,&quot;map&quot;:&quot;gender&quot;},\
                 {&quot;maptype&quot;:&quot;EventAttributeClass.Name&quot;,&quot;value&quot;:&quot;Dimension 5&quot;,&quot;map&quot;:&quot;sex&quot;},\
                 {&quot;maptype&quot;:&quot;EventAttributeClass.Name&quot;,&quot;value&quot;:&quot;Dimension 3&quot;,&quot;map&quot;:&quot;size&quot;},\
-                {&quot;maptype&quot;:&quot;EventAttributeClass.Name&quot;,&quot;value&quot;:&quot;Dimension 4&quot;,&quot;map&quot;:&quot;color&quot;},\
                 {&quot;maptype&quot;:&quot;ProductAttributeSelector.Name&quot;,&quot;value&quot;:&quot;Dimension 1&quot;,&quot;map&quot;:&quot;color&quot;},\
                 {&quot;maptype&quot;:&quot;ProductAttributeSelector.Name&quot;,&quot;value&quot;:&quot;Dimension 2&quot;,&quot;map&quot;:&quot;gender&quot;},\
                 {&quot;maptype&quot;:&quot;ProductAttributeSelector.Name&quot;,&quot;value&quot;:&quot;Dimension 3&quot;,&quot;map&quot;:&quot;size&quot;},\


### PR DESCRIPTION
Added large tests, and did a global find/replace of data --> event as this is a bit more clear. Actual code changes are sub 50 lines.

In this PR, we implement user timing events. Google docs [are here](https://developers.google.com/analytics/devguides/collection/analyticsjs/user-timings) for implementation. I mimicked the behavior of the server forwarder which applies `dimensions`/`metrics` and sends 2 events - the regular event, as well as the user timing event.

In summary, to send a user timing event, custom flags must be passed to any event logging:
```
var customFlags = {
   'Google.UserTiming': 123, //required
   'Google.Category': 'Foo-category', //required
   'Google.Label': 'Foo-label' // optional
};
mParticle.logEvent('test-event', mParticle.EventType.Other, {}, customFlags);
```

