### PR TITLE
Feat - support multiple content groups

### DIFF
--- a/test/index.html
+++ b/test/index.html
@@ -39,7 +39,7 @@
         window.ga = window.googleanalytics.ga;
         window._gaq = [];
     </script>
-    <script src="../googleanalyticseventforwarder.js" data-cover></script>
+    <script src="../dist/GoogleAnalyticsEventForwarder.iife.js" data-cover></script>
 
     <script>mocha.setup('bdd')</script>
 

--- a/test/tests.js
+++ b/test/tests.js
@@ -1553,30 +1553,41 @@ describe('Google Analytics Forwarder', function() {
         done();
     });
 
-    it('should set a content group when initialized with the proper custom flags', function(done) {
-        window.googleanalytics.reset();
-
-        mParticle.forwarder.init(
-            {
-                clientIdentificationType: 'AMP',
+    it('should set a content group on a page view when customFlags are set', function(done) {
+        var event = {
+            EventDataType: MessageType.PageView,
+            CustomFlags: {
+                'Google.CG1': 'value1',
+                'Google.CG2': 'value2',
+                'Google.CG3': 'value3',
+                'Google.CG4': 'value4',
+                'Google.CG5': 'value5',
             },
-            reportService.cb,
-            true,
-            'tracker-name',
-            null,
-            null,
-            null,
-            null,
-            {
-                'Google.CGNumber': '5',
-                'Google.CGValue': '/abc/def/',
-            }
-        );
+        };
+        mParticle.forwarder.process(event);
 
-        window.googleanalytics.args[0][0].should.equal('create');
-        window.googleanalytics.args[1][0].should.equal('tracker-name.set');
-        window.googleanalytics.args[1][1].should.equal('contentGroup5');
-        window.googleanalytics.args[1][2].should.equal('/abc/def/');
+        window.googleanalytics.args[0][0].should.equal('tracker-name.send');
+        window.googleanalytics.args[0][1].should.equal('pageview');
+        window.googleanalytics.args[0][2].should.have.property(
+            'contentGroup1',
+            'value1'
+        );
+        window.googleanalytics.args[0][2].should.have.property(
+            'contentGroup2',
+            'value2'
+        );
+        window.googleanalytics.args[0][2].should.have.property(
+            'contentGroup3',
+            'value3'
+        );
+        window.googleanalytics.args[0][2].should.have.property(
+            'contentGroup4',
+            'value4'
+        );
+        window.googleanalytics.args[0][2].should.have.property(
+            'contentGroup5',
+            'value5'
+        );
 
         done();
     });
@@ -1586,25 +1597,43 @@ describe('Google Analytics Forwarder', function() {
             EventDataType: MessageType.PageEvent,
             EventName: 'Test Page Event',
             CustomFlags: {
-                'Google.CGNumber': '3',
-                'Google.CGValue': 'abc',
+                'Google.CG1': 'value1',
+                'Google.CG2': 'value2',
+                'Google.CG3': 'value3',
+                'Google.CG4': 'value4',
+                'Google.CG5': 'value5',
             },
             EventCategory: EventType.Location,
         });
-
-        window.googleanalytics.args[0][0].should.equal('tracker-name.set');
-        window.googleanalytics.args[0][1].should.equal('contentGroup3');
-        window.googleanalytics.args[0][2].should.equal('abc');
-
-        window.googleanalytics.args[1][0].should.equal('tracker-name.send');
-        window.googleanalytics.args[1][1].should.equal('event');
-        window.googleanalytics.args[1][2].should.equal('Location');
-        window.googleanalytics.args[1][3].should.equal('Test Page Event');
+        window.googleanalytics.args[0][0].should.equal('tracker-name.send');
+        window.googleanalytics.args[0][1].should.equal('event');
+        window.googleanalytics.args[0][2].should.equal('Location');
+        window.googleanalytics.args[0][3].should.equal('Test Page Event');
+        window.googleanalytics.args[0][6].should.have.property(
+            'contentGroup1',
+            'value1'
+        );
+        window.googleanalytics.args[0][6].should.have.property(
+            'contentGroup2',
+            'value2'
+        );
+        window.googleanalytics.args[0][6].should.have.property(
+            'contentGroup3',
+            'value3'
+        );
+        window.googleanalytics.args[0][6].should.have.property(
+            'contentGroup4',
+            'value4'
+        );
+        window.googleanalytics.args[0][6].should.have.property(
+            'contentGroup5',
+            'value5'
+        );
 
         done();
     });
 
-    it('should set a content group on a commerce event log when customFlags are set', function(done) {
+    it.only('should set a content group on a commerce event log when customFlags are set', function(done) {
         mParticle.forwarder.process({
             EventName: 'eCommerce - Purchase',
             EventDataType: MessageType.Commerce,
@@ -1631,35 +1660,147 @@ describe('Google Analytics Forwarder', function() {
                 CouponCode: null,
             },
             CustomFlags: {
-                'Google.CGNumber': '2',
-                'Google.CGValue': 'abc',
+                'Google.CG1': 'value1',
+                'Google.CG2': 'value2',
+                'Google.CG3': 'value3',
+                'Google.CG4': 'value4',
+                'Google.CG5': 'value5',
             },
         });
 
-        window.googleanalytics.args[0][0].should.equal('tracker-name.set');
-        window.googleanalytics.args[0][1].should.equal('contentGroup2');
-        window.googleanalytics.args[0][2].should.equal('abc');
+        window.googleanalytics.args[3][4].should.have.property(
+            'contentGroup1',
+            'value1'
+        );
+        window.googleanalytics.args[3][4].should.have.property(
+            'contentGroup2',
+            'value2'
+        );
+        window.googleanalytics.args[3][4].should.have.property(
+            'contentGroup3',
+            'value3'
+        );
+        window.googleanalytics.args[3][4].should.have.property(
+            'contentGroup4',
+            'value4'
+        );
+        window.googleanalytics.args[3][4].should.have.property(
+            'contentGroup5',
+            'value5'
+        );
 
         done();
     });
 
-    it('should set a content group on a page view when customFlags are set', function(done) {
-        var event = {
-            EventDataType: MessageType.PageView,
-            CustomFlags: {
-                'Google.CGNumber': '2',
-                'Google.CGValue': 'abc',
-            },
-        };
-        mParticle.forwarder.process(event);
+    describe('ContentGroup tests to be deprecated on 3/1/2021', function() {
+        it('should set a content group when initialized with the proper custom flags', function(done) {
+            window.googleanalytics.reset();
 
-        window.googleanalytics.args[0][0].should.equal('tracker-name.set');
-        window.googleanalytics.args[0][1].should.equal('contentGroup2');
-        window.googleanalytics.args[0][2].should.equal('abc');
+            mParticle.forwarder.init(
+                {
+                    clientIdentificationType: 'AMP',
+                },
+                reportService.cb,
+                true,
+                'tracker-name',
+                null,
+                null,
+                null,
+                null,
+                {
+                    'Google.CGNumber': '5',
+                    'Google.CGValue': '/abc/def/',
+                }
+            );
 
-        window.googleanalytics.args[1][0].should.equal('tracker-name.send');
-        window.googleanalytics.args[1][1].should.equal('pageview');
+            window.googleanalytics.args[0][0].should.equal('create');
+            window.googleanalytics.args[1][0].should.equal('tracker-name.set');
+            window.googleanalytics.args[1][1].should.equal('contentGroup5');
+            window.googleanalytics.args[1][2].should.equal('/abc/def/');
 
-        done();
+            done();
+        });
+
+        it('should set a content group on a regular event log when customFlags are set', function(done) {
+            mParticle.forwarder.process({
+                EventDataType: MessageType.PageEvent,
+                EventName: 'Test Page Event',
+                CustomFlags: {
+                    'Google.CGNumber': '3',
+                    'Google.CGValue': 'abc',
+                },
+                EventCategory: EventType.Location,
+            });
+
+            window.googleanalytics.args[0][0].should.equal('tracker-name.set');
+            window.googleanalytics.args[0][1].should.equal('contentGroup3');
+            window.googleanalytics.args[0][2].should.equal('abc');
+
+            window.googleanalytics.args[1][0].should.equal('tracker-name.send');
+            window.googleanalytics.args[1][1].should.equal('event');
+            window.googleanalytics.args[1][2].should.equal('Location');
+            window.googleanalytics.args[1][3].should.equal('Test Page Event');
+
+            done();
+        });
+
+        it('should set a content group on a commerce event log when customFlags are set', function(done) {
+            mParticle.forwarder.process({
+                EventName: 'eCommerce - Purchase',
+                EventDataType: MessageType.Commerce,
+                EventCategory: CommerceEventType.ProductPurchase,
+                ProductAction: {
+                    ProductActionType: ProductActionType.Purchase,
+                    ProductList: [
+                        {
+                            Sku: '12345',
+                            Name: 'iPhone 6',
+                            Category: 'Phones',
+                            Brand: 'iPhone',
+                            Variant: '6',
+                            Price: 400,
+                            CouponCode: null,
+                            Quantity: 1,
+                        },
+                    ],
+                    TransactionId: 123,
+                    Affiliation: 'my-affiliation',
+                    TotalAmount: 450,
+                    TaxAmount: 40,
+                    ShippingAmount: 10,
+                    CouponCode: null,
+                },
+                CustomFlags: {
+                    'Google.CGNumber': '2',
+                    'Google.CGValue': 'abc',
+                },
+            });
+
+            window.googleanalytics.args[0][0].should.equal('tracker-name.set');
+            window.googleanalytics.args[0][1].should.equal('contentGroup2');
+            window.googleanalytics.args[0][2].should.equal('abc');
+
+            done();
+        });
+
+        it('should set a content group on a page view when customFlags are set', function(done) {
+            var event = {
+                EventDataType: MessageType.PageView,
+                CustomFlags: {
+                    'Google.CGNumber': '2',
+                    'Google.CGValue': 'abc',
+                },
+            };
+            mParticle.forwarder.process(event);
+
+            window.googleanalytics.args[0][0].should.equal('tracker-name.set');
+            window.googleanalytics.args[0][1].should.equal('contentGroup2');
+            window.googleanalytics.args[0][2].should.equal('abc');
+
+            window.googleanalytics.args[1][0].should.equal('tracker-name.send');
+            window.googleanalytics.args[1][1].should.equal('pageview');
+
+            done();
+        });
     });
 });

--- a/test/tests.js
+++ b/test/tests.js
@@ -1633,7 +1633,7 @@ describe('Google Analytics Forwarder', function() {
         done();
     });
 
-    it.only('should set a content group on a commerce event log when customFlags are set', function(done) {
+    it('should set a content group on a commerce event log when customFlags are set', function(done) {
         mParticle.forwarder.process({
             EventName: 'eCommerce - Purchase',
             EventDataType: MessageType.Commerce,
@@ -1667,24 +1667,24 @@ describe('Google Analytics Forwarder', function() {
                 'Google.CG5': 'value5',
             },
         });
-
-        window.googleanalytics.args[3][4].should.have.property(
+        console.log(window.googleanalytics.args);
+        window.googleanalytics.args[2][4].should.have.property(
             'contentGroup1',
             'value1'
         );
-        window.googleanalytics.args[3][4].should.have.property(
+        window.googleanalytics.args[2][4].should.have.property(
             'contentGroup2',
             'value2'
         );
-        window.googleanalytics.args[3][4].should.have.property(
+        window.googleanalytics.args[2][4].should.have.property(
             'contentGroup3',
             'value3'
         );
-        window.googleanalytics.args[3][4].should.have.property(
+        window.googleanalytics.args[2][4].should.have.property(
             'contentGroup4',
             'value4'
         );
-        window.googleanalytics.args[3][4].should.have.property(
+        window.googleanalytics.args[2][4].should.have.property(
             'contentGroup5',
             'value5'
         );


### PR DESCRIPTION
This PR adds a deprecation warning for the previous implementation of content groups. 

Previously, we implemented an API for custom flags `Google.CGNumber` and `Google.CGValue` based on the understanding that only 1 content group would be used at a time.  However, we now understand that multiple content groups can be implemented per event. So the new api is a custom flag of `Google.CG1/2/3/4/5`, with their respective values.

Content groups now are added to each event via the `fieldsObject`. Previously this was named `outputDimensionsAndMetrics` because that's all we were using the `fieldsObject` for. Since it takes more than just dimensions and metrics, I am renaming all instances of `outputDimensionsAndMetrics` --> `fieldsObject`, which is the term GA uses.

EDIT 11/30/2020 11:43 AM - GA uses the term `fieldsObject`, but it's a pretty confusing term, as Alex commented below. I was just trying to be consistent with GA, but I am renaming this to something more explicit - `gaOptionalParameters` to be more reader friendly.