### PR TITLE
Refactor variable declaration for attrName

### DIFF
--- a/src/GoogleAnalyticsEventForwarder.js
+++ b/src/GoogleAnalyticsEventForwarder.js
@@ -93,8 +93,10 @@
         }
 
         function applyCustomDimensionsMetricsForSourceAttributes(attributes, targetDimensionsAndMetrics, mapLevel) {
+            var attrName;
+
             for (var customDimension in mapLevel.customDimensions) {
-                for (var attrName in attributes) {
+                for (attrName in attributes) {
                     if (customDimension === attrName) {
                         mapLevel.customDimensions[customDimension].forEach(function(cd) {
                             if (!targetDimensionsAndMetrics[cd]) {

--- a/src/GoogleAnalyticsEventForwarder.js
+++ b/src/GoogleAnalyticsEventForwarder.js
@@ -1,3 +1,4 @@
+"use strict"
 //
 //  Copyright 2019 mParticle, Inc.
 //
@@ -93,14 +94,12 @@
         }
 
         function applyCustomDimensionsMetricsForSourceAttributes(attributes, targetDimensionsAndMetrics, mapLevel) {
-            var attrName;
-
             for (var customDimension in mapLevel.customDimensions) {
-                for (attrName in attributes) {
-                    if (customDimension === attrName) {
+                for (var attrDimName in attributes) {
+                    if (customDimension === attrDimName) {
                         mapLevel.customDimensions[customDimension].forEach(function(cd) {
                             if (!targetDimensionsAndMetrics[cd]) {
-                                targetDimensionsAndMetrics[cd] = attributes[attrName];
+                                targetDimensionsAndMetrics[cd] = attributes[attrDimName];
                             }
                         })
                     }
@@ -108,11 +107,11 @@
             }
 
             for (var customMetric in mapLevel.customMetrics) {
-                for (attrName in attributes) {
-                    if (customMetric === attrName) {
+                for (var attrMetricName in attributes) {
+                    if (customMetric === attrMetricName) {
                         mapLevel.customMetrics[customMetric].forEach(function(cm) {
                             if (!targetDimensionsAndMetrics[cm]) {
-                                targetDimensionsAndMetrics[cm] = attributes[attrName];
+                                targetDimensionsAndMetrics[cm] = attributes[attrMetricName];
                             }
                         })
                     }

--- a/src/GoogleAnalyticsEventForwarder.js
+++ b/src/GoogleAnalyticsEventForwarder.js
@@ -1,4 +1,3 @@
-"use strict"
 //
 //  Copyright 2019 mParticle, Inc.
 //


### PR DESCRIPTION
Declaring `attrName` at the top of the function `applyCustomDimensionsMetricsForSourceAttributes `. 

Previously it was only added to line 97 (new file line 99), and not 109 (new file line 111).  In strict mode, line 109 in the old file 109 would throw an error of being undeclared even though declaring the variable on line 97 should be hoisted.