### PR TITLE
fix: Set custom dimensions for product impressions

### DIFF
--- a/src/GoogleAnalyticsEventForwarder.js
+++ b/src/GoogleAnalyticsEventForwarder.js
@@ -217,15 +217,26 @@
             ga(createCmd('ec:addProduct'), productAttrs);
         }
 
-        function addEcommerceProductImpression(product) {
-            ga(createCmd('ec:addImpression'), {
+        function addEcommerceProductImpression(product, updatedProductDimentionAndMetrics) {
+            var productAttrs = {
                 id: product.Sku,
                 name: product.Name,
-                type: 'view',
                 category: product.Category,
                 brand: product.Brand,
-                variant: product.Variant
-            });
+                variant: product.Variant,
+                price: product.Price,
+                coupon: product.CouponCode,
+                quantity: product.Quantity,
+                type: 'view'
+            };
+
+            for (var attr in updatedProductDimentionAndMetrics) {
+                if (updatedProductDimentionAndMetrics.hasOwnProperty(attr)) {
+                    productAttrs[attr] = updatedProductDimentionAndMetrics[attr];
+                }
+            }
+
+            ga(createCmd('ec:addImpression'), productAttrs);
         }
 
         function sendEcommerceEvent(type, gaOptionalParameters, customFlags) {
@@ -247,7 +258,9 @@
                 // Impression event
                 event.ProductImpressions.forEach(function(impression) {
                     impression.ProductList.forEach(function(product) {
-                        addEcommerceProductImpression(product);
+                        var updatedProductDimentionAndMetrics = {};
+                        applyCustomDimensionsMetricsForSourceAttributes(product.Attributes, updatedProductDimentionAndMetrics, productLevelMap);
+                        addEcommerceProductImpression(product, updatedProductDimentionAndMetrics);
                     });
                 });
 
@@ -487,7 +500,6 @@
                             if (forwarderSettings.useDisplayFeatures == 'True') {
                                 ga.src = ('https:' == document.location.protocol ? 'https://' : 'http://') + 'stats.g.doubleclick.net/dc.js';
                             } else {
-                                
                                 ga.src = ('https:' == document.location.protocol ? 'https://ssl' : 'http://www') + '.google-analytics.com/ga.js';
                             }
                             var s = document.getElementsByTagName('script')[0]; s.parentNode.insertBefore(ga, s);
@@ -557,7 +569,7 @@
                 }
 
                 isInitialized = true;
-                
+
                 if (window.mParticle.getVersion().split('.')[0] === '2') {
                     onUserIdentified(mParticle.Identity.getCurrentUser());
                 }

--- a/test/tests.js
+++ b/test/tests.js
@@ -481,6 +481,86 @@ describe('Google Analytics Forwarder', function() {
         mParticle.forwarder.process(event);
         window.googleanalytics.args[2][1].should.equal('abcdef');
 
+        window.googleanalytics.args = [];
+
+        done();
+    });
+
+    it('should log custom dimensions and metrics with a product impression', function(done) {
+        var event = {
+            EventDataType: MessageType.Commerce,
+            EventCategory: CommerceEventType.ProductImpression,
+            ProductImpressions: [
+                {
+                    ProductionImpressionList: 'testImp',
+                    ProductList: [
+                        {
+                            Sku: '12345',
+                            Name: 'iPhone 6',
+                            Category: 'Phones',
+                            Brand: 'iPhone',
+                            Variant: '6',
+                            Price: 400,
+                            CouponCode: null,
+                            Quantity: 1,
+                            Attributes: {
+                                gender: 'female',
+                                color: 'blue',
+                                size: 'large',
+                                levels: 1,
+                                shots: 15,
+                                players: 3,
+                            },
+                            TotalAmount: 100,
+                        },
+                    ],
+                },
+            ],
+        };
+
+        mParticle.forwarder.process(event);
+
+        window.googleanalytics.args[0][0].should.equal(
+            'tracker-name.ec:addImpression'
+        );
+        window.googleanalytics.args[0][1].should.have.property('id', '12345');
+        window.googleanalytics.args[0][1].should.have.property(
+            'name',
+            'iPhone 6'
+        );
+        window.googleanalytics.args[0][1].should.have.property(
+            'category',
+            'Phones'
+        );
+        window.googleanalytics.args[0][1].should.have.property(
+            'brand',
+            'iPhone'
+        );
+        window.googleanalytics.args[0][1].should.have.property('variant', '6');
+        window.googleanalytics.args[0][1].should.have.property('price', 400);
+        window.googleanalytics.args[0][1].should.have.property('coupon', null);
+        window.googleanalytics.args[0][1].should.have.property('quantity', 1);
+        window.googleanalytics.args[0][1].should.have.property(
+            'dimension1',
+            'blue'
+        );
+        window.googleanalytics.args[0][1].should.have.property(
+            'dimension2',
+            'female'
+        );
+        window.googleanalytics.args[0][1].should.have.property(
+            'dimension3',
+            'large'
+        );
+        window.googleanalytics.args[0][1].should.have.property('metric1', 1);
+        window.googleanalytics.args[0][1].should.have.property('metric2', 15);
+        window.googleanalytics.args[0][1].should.have.property('metric3', 3);
+
+        window.googleanalytics.args[1][0].should.equal('tracker-name.send');
+        window.googleanalytics.args[1][1].should.equal('event');
+        window.googleanalytics.args[1][2].should.equal('eCommerce');
+        window.googleanalytics.args[1][3].should.equal('Product Impression');
+
         done();
     });
 


### PR DESCRIPTION
This PR enables product impressions to also include custom dimensions when product attributes are mapped.