### PR TITLE
fix: Implement hashUserId and externalUserIdentityType settings

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -1,10 +1,12 @@
 {
     "env": {
-        "browser": true
+        "browser": true,
+        "node": true
     },
     "globals": {
         "ga": "readonly",
-        "_gaq": "readonly"
+        "_gaq": "readonly",
+        "mParticle": true
     },
     "extends": ["plugin:prettier/recommended", "eslint:recommended"],
     "plugins": ["prettier"],

--- a/src/GoogleAnalyticsEventForwarder.js
+++ b/src/GoogleAnalyticsEventForwarder.js
@@ -244,7 +244,7 @@
                             userId = userIdentities.other10;
                             break;
                         default:
-                            console.warn('External identity type not found for setting identity on ' + kitName)
+                            console.warn('External identity type not found for setting identity on ' + kitName + '. User not set. Please double check your implementation.')
                     }
                 }
                 if (userId) {

--- a/src/GoogleAnalyticsEventForwarder.js
+++ b/src/GoogleAnalyticsEventForwarder.js
@@ -13,7 +13,7 @@
 //  See the License for the specific language governing permissions and
 //  limitations under the License.
 
-    var kitName = 'GoogleAnalyticsEventForwarder',
+    var name = 'GoogleAnalyticsEventForwarder',
         moduleId = 6,
         version = '2.1.10',
         MessageType = {
@@ -77,7 +77,7 @@
                 customMetrics: {}
             };
 
-        self.name = kitName;
+        self.name = name;
 
         function createTrackerId() {
             return 'mpgaTracker' + trackerCount++;
@@ -205,6 +205,9 @@
         }
 
         function onUserIdentified(user) {
+            if (!user) {
+                return;
+            }
             var userId,
                 userIdentities = user.getUserIdentities().userIdentities;
             if (isInitialized) {
@@ -244,7 +247,7 @@
                             userId = userIdentities.other10;
                             break;
                         default:
-                            console.warn('External identity type not found for setting identity on ' + kitName + '. User not set. Please double check your implementation.')
+                            console.warn('External identity type not found for setting identity on ' + name + '. User not set. Please double check your implementation.')
                     }
                 }
                 if (userId) {

--- a/src/GoogleAnalyticsEventForwarder.js
+++ b/src/GoogleAnalyticsEventForwarder.js
@@ -13,7 +13,7 @@
 //  See the License for the specific language governing permissions and
 //  limitations under the License.
 
-    var name = 'GoogleAnalyticsEventForwarder',
+    var kitName = 'GoogleAnalyticsEventForwarder',
         moduleId = 6,
         version = '2.1.10',
         MessageType = {
@@ -26,6 +26,21 @@
             Commerce: 16
         },
         trackerCount = 1,
+        externalUserIdentityType = {
+            none: 'None',
+            customerId: "CustomerId",
+            other: "Other",
+            other2: "Other2",
+            other3: "Other3",
+            other4: "Other4",
+            other5: "Other5",
+            other6: "Other6",
+            other7: "Other7",
+            other8: "Other8",
+            other9: "Other9",
+            other10: "Other10",
+        },
+
         NON_INTERACTION_FLAG = 'Google.NonInteraction',
         CATEGORY = 'Google.Category',
         LABEL = 'Google.Label',
@@ -62,7 +77,7 @@
                 customMetrics: {}
             };
 
-        self.name = name;
+        self.name = kitName;
 
         function createTrackerId() {
             return 'mpgaTracker' + trackerCount++;
@@ -170,7 +185,7 @@
         function setUserIdentity(id, type) {
             if (window.mParticle.getVersion().split('.')[0] === '1') {
                 if (isInitialized) {
-                    if (forwarderSettings.useCustomerId == 'True' && type == window.mParticle.IdentityType.CustomerId) {
+                    if (forwarderSettings.hashUserId == 'True' && type == window.mParticle.IdentityType.CustomerId) {
                         if (forwarderSettings.classicMode == 'True') {
                             // ga.js not supported currently
                         }
@@ -185,14 +200,64 @@
             }
         }
 
+        function generateHash(id) {
+            return window.mParticle.generateHash(id);
+        }
+
         function onUserIdentified(user) {
-            var userIdentities = user.getUserIdentities().userIdentities;
+            var userId,
+                userIdentities = user.getUserIdentities().userIdentities;
             if (isInitialized) {
-                if (forwarderSettings.useCustomerId == 'True' && userIdentities.customerid) {
-                    if (forwarderSettings.classicMode !== 'True') {
-                        ga(createCmd('set'), 'userId', window.mParticle.generateHash(userIdentities.customerid));
+                if (forwarderSettings.externalUserIdentityType !== externalUserIdentityType.none) {
+                    switch (forwarderSettings.externalUserIdentityType) {
+                        case "CustomerId":
+                            userId = userIdentities.customerid;
+                            break;
+                        case "Other":
+                            userId = userIdentities.other;
+                            break;
+                        case "Other2":
+                            userId = userIdentities.other2;
+                            break;
+                        case "Other3":
+                            userId = userIdentities.other3;
+                            break;
+                        case "Other4":
+                            userId = userIdentities.other4;
+                            break;
+                        case "Other5":
+                            userId = userIdentities.other5;
+                            break;
+                        case "Other6":
+                            userId = userIdentities.other6;
+                            break;
+                        case "Other7":
+                            userId = userIdentities.other7;
+                            break;
+                        case "Other8":
+                            userId = userIdentities.other8;
+                            break;
+                        case "Other9":
+                            userId = userIdentities.other9;
+                            break;
+                        case "Other10":
+                            userId = userIdentities.other10;
+                            break;
+                        default:
+                            console.warn('External identity type not found for setting identity on ' + kitName)
                     }
                 }
+                if (userId) {
+                    if (forwarderSettings.hashUserId == 'True') {
+                        userId = generateHash(userId);
+                    }
+                    if (forwarderSettings.classicMode !== 'True') {
+                        ga(createCmd('set'), 'userId', userId);
+                    }
+                } else {
+                    console.warn('External identity type of ' + forwarderSettings.externalUserIdentityType + ' not set on the user');
+                }
+                
             }
         }
 

--- a/test/tests.js
+++ b/test/tests.js
@@ -132,7 +132,21 @@ describe('Google Analytics Forwarder', function() {
                 this.event = null;
             };
         },
-        reportService = new ReportingService();
+        reportService = new ReportingService(),
+        externalUserIdentityType = {
+            none: 'None',
+            customerId: 'CustomerId',
+            other: 'Other',
+            other2: 'Other2',
+            other3: 'Other3',
+            other4: 'Other4',
+            other5: 'Other5',
+            other6: 'Other6',
+            other7: 'Other7',
+            other8: 'Other8',
+            other9: 'Other9',
+            other10: 'Other10',
+        };
 
     before(function() {
         mParticle.EventType = EventType;
@@ -189,7 +203,7 @@ describe('Google Analytics Forwarder', function() {
     beforeEach(function() {
         mParticle.forwarder.init(
             {
-                useCustomerId: 'True',
+                hashUserId: 'True',
                 customDimensions:
                     '[\
                 {&quot;maptype&quot;:&quot;EventAttributeClass.Name&quot;,&quot;value&quot;:&quot;Dimension 1&quot;,&quot;map&quot;:&quot;color&quot;},\
@@ -231,13 +245,13 @@ describe('Google Analytics Forwarder', function() {
 
         mParticle.forwarder.init(
             {
-                useCustomerId: 'True',
+                hashUserId: 'True',
+                externalUserIdentityType: externalUserIdentityType.customerId,
             },
             reportService.cb,
             true,
             'tracker-name'
         );
-
         window.googleanalytics.args[1][0].should.equal('tracker-name.set');
         window.googleanalytics.args[1][1].should.equal('userId');
         (typeof window.googleanalytics.args[1][2]).should.equal('number');
@@ -1747,7 +1761,7 @@ describe('Google Analytics Forwarder', function() {
                 'Google.CG5': 'value5',
             },
         });
-        console.log(window.googleanalytics.args);
+
         window.googleanalytics.args[2][4].should.have.property(
             'contentGroup1',
             'value1'
@@ -1882,5 +1896,109 @@ describe('Google Analytics Forwarder', function() {
 
             done();
         });
+    });
+
+    it('should not hash a user id when hashUserId is false', function(done) {
+        window.googleanalytics.reset();
+
+        mParticle.forwarder.init(
+            {
+                hashUserId: 'False',
+                externalUserIdentityType: externalUserIdentityType.customerId,
+            },
+            reportService.cb,
+            true,
+            'tracker-name'
+        );
+        window.googleanalytics.args[1][0].should.equal('tracker-name.set');
+        window.googleanalytics.args[1][1].should.equal('userId');
+
+        window.googleanalytics.args[1][2].should.equal(
+            mParticle.Identity.getCurrentUser().getUserIdentities()
+                .userIdentities.customerid
+        );
+
+        done();
+    });
+
+    it('should set the proper Other external user identity type', function(done) {
+        function resetAndInitGA(userIdType) {
+            window.googleanalytics.reset();
+            mParticle.forwarder.init(
+                {
+                    hashUserId: 'False',
+                    externalUserIdentityType: userIdType,
+                },
+                reportService.cb,
+                true,
+                'tracker-name'
+            );
+        }
+
+        mParticle.Identity.getCurrentUser = function() {
+            return {
+                getUserIdentities: function() {
+                    return {
+                        userIdentities: {
+                            other: 'other',
+                            other2: 'other2',
+                            other3: 'other3',
+                            other4: 'other4',
+                            other5: 'other5',
+                            other6: 'other6',
+                            other7: 'other7',
+                            other8: 'other8',
+                            other9: 'other9',
+                            other10: 'other10',
+                        },
+                    };
+                },
+            };
+        };
+
+        var otherIds = mParticle.Identity.getCurrentUser().getUserIdentities()
+            .userIdentities;
+        var other1 = otherIds.other;
+        var other2 = otherIds.other2;
+        var other3 = otherIds.other3;
+        var other4 = otherIds.other4;
+        var other5 = otherIds.other5;
+        var other6 = otherIds.other6;
+        var other7 = otherIds.other7;
+        var other8 = otherIds.other8;
+        var other9 = otherIds.other9;
+        var other10 = otherIds.other10;
+
+        resetAndInitGA(externalUserIdentityType.other);
+        window.googleanalytics.args[1][2].should.equal(other1);
+
+        resetAndInitGA(externalUserIdentityType.other2);
+        window.googleanalytics.args[1][2].should.equal(other2);
+
+        resetAndInitGA(externalUserIdentityType.other3);
+        window.googleanalytics.args[1][2].should.equal(other3);
+
+        resetAndInitGA(externalUserIdentityType.other4);
+        window.googleanalytics.args[1][2].should.equal(other4);
+
+        resetAndInitGA(externalUserIdentityType.other5);
+        window.googleanalytics.args[1][2].should.equal(other5);
+
+        resetAndInitGA(externalUserIdentityType.other6);
+        window.googleanalytics.args[1][2].should.equal(other6);
+
+        resetAndInitGA(externalUserIdentityType.other7);
+        window.googleanalytics.args[1][2].should.equal(other7);
+
+        resetAndInitGA(externalUserIdentityType.other8);
+        window.googleanalytics.args[1][2].should.equal(other8);
+
+        resetAndInitGA(externalUserIdentityType.other9);
+        window.googleanalytics.args[1][2].should.equal(other9);
+
+        resetAndInitGA(externalUserIdentityType.other10);
+        window.googleanalytics.args[1][2].should.equal(other10);
+
+        done();
     });
 });


### PR DESCRIPTION
Previously there was a single boolean setting that was used - `Hash Customer Id` which equated to setting `useCustomerId`. This only allowed GA kit users to choose `customerid` as the identity type used for GA and it had to be hashed. 

A new dropdown box was added as a setting, `externalUserIdentityType`, as well as a new boolean `Hash User Id`. This PR allows supporting these new settings and deprecates use of `useCustomerId`.  `externalUserIdentityType` is maped as follows
```
[
  {
    "name": "None",
    "value": "None"
  },
  {
    "name": "Customer Id",
    "value": "CustomerId"
  },
  {
    "name": "Other",
    "value": "Other"
  },
  {
    "name": "Other2",
    "value": "Other2"
  },
  {
    "name": "Other3",
    "value": "Other3"
  },
  {
    "name": "Other4",
    "value": "Other4"
  },
  {
    "name": "Other5",
    "value": "Other5"
  },
  {
    "name": "Other6",
    "value": "Other6"
  },
  {
    "name": "Other7",
    "value": "Other7"
  },
  {
    "name": "Other8",
    "value": "Other8"
  },
  {
    "name": "Other9",
    "value": "Other9"
  },
  {
    "name": "Other10",
    "value": "Other10"
  }
]
```
![image](https://user-images.githubusercontent.com/5377436/118020993-c3349900-b328-11eb-93e4-d0790b5a332f.png)
