### PR TITLE
fix: Add Location and Hostname to support all GA content information

### DIFF
--- a/src/GoogleAnalyticsEventForwarder.js
+++ b/src/GoogleAnalyticsEventForwarder.js
@@ -46,6 +46,8 @@
         LABEL = 'Google.Label',
         TITLE = 'Google.Title',
         PAGE = 'Google.Page',
+        LOCATION = 'Google.Location',
+        HOSTNAME = 'Google.Host',
         VALUE = 'Google.Value',
         USERTIMING = 'Google.UserTiming',
         HITTYPE = 'Google.HitType',
@@ -447,8 +449,15 @@
                 _gaq.push(['_trackPageview']);
             }
             else {
+                debugger;
                 if (event.CustomFlags && event.CustomFlags[PAGE]) {
                     ga(createCmd('set'), 'page', event.CustomFlags[PAGE]);
+                }
+                if (event.CustomFlags && event.CustomFlags[HOSTNAME]) {
+                    ga(createCmd('set'), 'hostname', event.CustomFlags[HOSTNAME]);
+                }
+                if (event.CustomFlags && event.CustomFlags[LOCATION]) {
+                    ga(createCmd('set'), 'location', event.CustomFlags[LOCATION]);
                 }
                 if (event.CustomFlags && event.CustomFlags[TITLE]){
                     ga(createCmd('set'), 'title', event.CustomFlags[TITLE]);

--- a/src/GoogleAnalyticsEventForwarder.js
+++ b/src/GoogleAnalyticsEventForwarder.js
@@ -449,17 +449,19 @@
                 _gaq.push(['_trackPageview']);
             }
             else {
-                if (event.CustomFlags && event.CustomFlags[PAGE]) {
-                    ga(createCmd('set'), 'page', event.CustomFlags[PAGE]);
-                }
-                if (event.CustomFlags && event.CustomFlags[HOSTNAME]) {
-                    ga(createCmd('set'), 'hostname', event.CustomFlags[HOSTNAME]);
-                }
-                if (event.CustomFlags && event.CustomFlags[LOCATION]) {
-                    ga(createCmd('set'), 'location', event.CustomFlags[LOCATION]);
-                }
-                if (event.CustomFlags && event.CustomFlags[TITLE]){
-                    ga(createCmd('set'), 'title', event.CustomFlags[TITLE]);
+                if (event.CustomFlags) {
+                    if (event.CustomFlags[PAGE]) {
+                        ga(createCmd('set'), 'page', event.CustomFlags[PAGE]);
+                    }
+                    if (event.CustomFlags[HOSTNAME]) {
+                        ga(createCmd('set'), 'hostname', event.CustomFlags[HOSTNAME]);
+                    }
+                    if (event.CustomFlags[LOCATION]) {
+                        ga(createCmd('set'), 'location', event.CustomFlags[LOCATION]);
+                    }
+                    if (event.CustomFlags[TITLE]){
+                        ga(createCmd('set'), 'title', event.CustomFlags[TITLE]);
+                    }
                 }
                 ga(createCmd('send'), customFlags && customFlags[HITTYPE] ? customFlags[HITTYPE] : 'pageview', gaOptionalParameters);
                 sendOptionalUserTimingMessage(event, gaOptionalParameters);

--- a/src/GoogleAnalyticsEventForwarder.js
+++ b/src/GoogleAnalyticsEventForwarder.js
@@ -449,7 +449,6 @@
                 _gaq.push(['_trackPageview']);
             }
             else {
-                debugger;
                 if (event.CustomFlags && event.CustomFlags[PAGE]) {
                     ga(createCmd('set'), 'page', event.CustomFlags[PAGE]);
                 }

--- a/src/GoogleAnalyticsEventForwarder.js
+++ b/src/GoogleAnalyticsEventForwarder.js
@@ -47,7 +47,7 @@
         TITLE = 'Google.Title',
         PAGE = 'Google.Page',
         LOCATION = 'Google.Location',
-        HOSTNAME = 'Google.Host',
+        HOSTNAME = 'Google.Hostname',
         VALUE = 'Google.Value',
         USERTIMING = 'Google.UserTiming',
         HITTYPE = 'Google.HitType',

--- a/test/tests.js
+++ b/test/tests.js
@@ -357,7 +357,7 @@ describe('Google Analytics Forwarder', function() {
             CustomFlags: {
                 'Google.Page': 'foo page',
                 'Google.Location': 'foo location',
-                'Google.Host': 'foo hostname'
+                'Google.Hostname': 'foo hostname'
             },
         });
 

--- a/test/tests.js
+++ b/test/tests.js
@@ -347,6 +347,35 @@ describe('Google Analytics Forwarder', function() {
         done();
     });
 
+    it('should set Page, Location, and Hostname if they are all provided via custom flags', function(done) {
+        mParticle.forwarder.process({
+            EventDataType: MessageType.PageView,
+            EventName: 'Test Page Event',
+            EventAttributes: {
+                anything: 'foo',
+            },
+            CustomFlags: {
+                'Google.Page': 'foo page',
+                'Google.Location': 'foo location',
+                'Google.Host': 'foo hostname'
+            },
+        });
+
+        window.googleanalytics.args[0][0].should.equal('tracker-name.set');
+        window.googleanalytics.args[0][1].should.equal('page');
+        window.googleanalytics.args[0][2].should.equal('foo page');
+
+        window.googleanalytics.args[1][0].should.equal('tracker-name.set');
+        window.googleanalytics.args[1][1].should.equal('hostname');
+        window.googleanalytics.args[1][2].should.equal('foo hostname');
+
+        window.googleanalytics.args[2][0].should.equal('tracker-name.set');
+        window.googleanalytics.args[2][1].should.equal('location');
+        window.googleanalytics.args[2][2].should.equal('foo location');
+
+        done();
+    });
+
     it('should log custom dimensions and custom events with an event log', function(done) {
         var event = {
             EventDataType: MessageType.PageEvent,


### PR DESCRIPTION
Previously only the content `Page` was supported.  Per [Google's docs](https://developers.google.com/analytics/devguides/collection/analyticsjs/field-reference#content), if you set `Page`, you should set `Hostname`.  You can also set `Location`. All fields can also be sent together.