### PR TITLE
feat: Add custom flag to customize Action

### DIFF
--- a/src/GoogleAnalyticsEventForwarder.js
+++ b/src/GoogleAnalyticsEventForwarder.js
@@ -51,6 +51,7 @@
         VALUE = 'Google.Value',
         USERTIMING = 'Google.UserTiming',
         HITTYPE = 'Google.HitType',
+        ACTION = 'Google.Action',
         CONTENTGROUPNUMBER = 'Google.CGNumber',
         CONTENTGROUPVALUE = 'Google.CGValue',
         CONTENTGROUP1 = 'Google.CG1',
@@ -471,7 +472,8 @@
         function logEvent(event, gaOptionalParameters, customFlags) {
             var label = '',
                 category = getEventTypeName(event.EventCategory),
-                value;
+                value,
+                action;
 
             if (event.EventAttributes) {
                 if (event.EventAttributes.label) {
@@ -495,7 +497,8 @@
             if (event.CustomFlags) {
                 var googleCategory = event.CustomFlags[CATEGORY],
                     googleLabel = event.CustomFlags[LABEL],
-                    googleValue = parseInt(event.CustomFlags[VALUE], 10);
+                    googleValue = parseInt(event.CustomFlags[VALUE], 10)
+                    googleAction = event.CustomFlags[ACTION];
 
                 if (googleCategory) {
                     category = googleCategory;
@@ -509,12 +512,16 @@
                 if (googleValue == googleValue) {
                     value = googleValue;
                 }
+
+                if (googleAction && typeof googleAction === 'string') {
+                    action = googleAction;
+                }
             }
 
             if (forwarderSettings.classicMode == 'True') {
                 _gaq.push(['_trackEvent',
                     category,
-                    event.EventName,
+                    action || event.EventName,
                     label,
                     value]);
             }
@@ -522,7 +529,7 @@
                 ga(createCmd('send'),
                     customFlags && customFlags[HITTYPE] ? customFlags[HITTYPE] : 'event',
                     category,
-                    event.EventName,
+                    action || event.EventName,
                     label,
                     value,
                     gaOptionalParameters

--- a/src/GoogleAnalyticsEventForwarder.js
+++ b/src/GoogleAnalyticsEventForwarder.js
@@ -497,7 +497,7 @@
             if (event.CustomFlags) {
                 var googleCategory = event.CustomFlags[CATEGORY],
                     googleLabel = event.CustomFlags[LABEL],
-                    googleValue = parseInt(event.CustomFlags[VALUE], 10)
+                    googleValue = parseInt(event.CustomFlags[VALUE], 10),
                     googleAction = event.CustomFlags[ACTION];
 
                 if (googleCategory) {

--- a/test/tests.js
+++ b/test/tests.js
@@ -375,6 +375,26 @@ describe('Google Analytics Forwarder', function() {
 
         done();
     });
+    
+    it('should set Action when provided via custom flags', function(done) {
+        mParticle.forwarder.process({
+            EventDataType: MessageType.PageEvent,
+            EventName: 'Test Page Event',
+            EventAttributes: {
+                anything: 'foo',
+            },
+            CustomFlags: {
+                'Google.Action': 'foo-action',
+            },
+        });
+
+        window.googleanalytics.args[0][0].should.equal('tracker-name.send');
+        window.googleanalytics.args[0][1].should.equal('event');
+        window.googleanalytics.args[0][2].should.equal('Other');
+        window.googleanalytics.args[0][3].should.equal('foo-action');
+
+        done();
+    });
 
     it('should log custom dimensions and custom events with an event log', function(done) {
         var event = {


### PR DESCRIPTION
## Summary
This resolves the feature request JIRA (https://go.mparticle.com/jira/pri-7363) that was marked as won't do since GA4 now is what recommended. However, we got a ticket earlier from SportsEngine that they still want to see this flag added. The flag is needed since some customers such as SportsEngine and Starbucks already hit their schema limit and don't want increase the schema events name. Currently by default, the event action param "ea" is mapped as the event's name, this flag will allow customers to use this flag instead of the event name if needed.

## Testing Plan
Tested locally with minified code with overrides and works as expected in both cases when flag is present it uses the flag as "ea" param, when flag is missing it defaults to the event's name.

## Other notes
This also needs to be added in the S2S integration as well which I don't have permission to edit or submit PRs
